### PR TITLE
OK-1036 muutetaan hakukohderyhmärajauksen toimintalogiikkaa

### DIFF
--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/CommonRepository.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/CommonRepository.scala
@@ -57,53 +57,6 @@ class CommonRepository extends Extractors {
     query
   }
 
-  def selectDistinctExistingHakukohteetWithSelectedOrgsAsJarjestaja(
-      orgs: List[String],
-      haut: List[String],
-      hakukohderyhmat: List[String],
-      hakukohteet: List[String]
-  ): SqlStreamingAction[Vector[Hakukohde], Hakukohde, Effect] = {
-    val organisaatiotStr = RepositoryUtils.makeListOfValuesQueryStr(orgs)
-    val organisaatiotQueryStr = if (organisaatiotStr.isEmpty) {
-      ""
-    } else { s"AND hk.jarjestyspaikka_oid in ($organisaatiotStr)" }
-
-    val hautStr = RepositoryUtils.makeListOfValuesQueryStr(haut)
-    val hautQueryStr = if (hautStr.isEmpty) {
-      ""
-    } else {
-      s"AND hk.haku_oid in ($hautStr)"
-    }
-
-    val hakukohderyhmatStr = RepositoryUtils.makeListOfValuesQueryStr(hakukohderyhmat)
-    val hakukohderyhmatQueryStr = if (hakukohderyhmatStr.isEmpty) {
-      ""
-    } else {
-      s"AND hkr_hk.hakukohderyhma_oid in ($hakukohderyhmatStr)"
-    }
-
-    val hakukohteetStr = RepositoryUtils.makeListOfValuesQueryStr(hakukohteet)
-    val hakukohteetQueryStr = if (hakukohteetStr.isEmpty) {
-      ""
-    } else {
-      s"OR hk.hakukohde_oid in ($hakukohteetStr)"
-    }
-
-    val query = sql"""SELECT DISTINCT hk.hakukohde_oid, hk.hakukohde_nimi
-          FROM pub.pub_dim_hakukohde hk
-          LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hkr_hk
-          ON hkr_hk.hakukohde_oid = hk.hakukohde_oid
-          WHERE hk.tila != 'poistettu'
-          #$organisaatiotQueryStr
-          #$hautQueryStr
-          #$hakukohderyhmatQueryStr
-          #$hakukohteetQueryStr
-          """.as[Hakukohde]
-
-    LOG.debug(s"selectDistinctExistingHakukohteetWithSelectedOrgsAsJarjestaja: ${query.statements.head}")
-    query
-  }
-
   def selectDistinctExistingHakukohteetWithOrgAndAndHakukohderyhmaFilter(
       orgs: List[String],
       isOrganisaatioRajain: Boolean,
@@ -138,7 +91,7 @@ class CommonRepository extends Extractors {
       #$hakukohteetQueryStr
     """.as[Hakukohde]
 
-    LOG.debug(s"selectDistinctExistingHakukohteetWithSelectedOrgsAsJarjestaja: ${query.statements.head}")
+    LOG.debug(s"selectDistinctExistingHakukohteetWithOrgAndAndHakukohderyhmaFilter: ${query.statements.head}")
     query
   }
 

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/KkHakeneetHyvaksytytVastaanottaneetRepository.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/KkHakeneetHyvaksytytVastaanottaneetRepository.scala
@@ -85,7 +85,7 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
 
   private def buildOrganisaatioKayttooikeusFilter(selectedKayttooikeusOrganisaatiot: List[String], isOrganisaatioRajain: Boolean, kayttooikeusHakukohderyhmat: List[String]) = {
     if (isOrganisaatioRajain) {
-      // jos organisaatio valittu, ei huomioida käyttäjän organisaatio ulkopuolisia hakukohderyhmiä
+      // jos organisaatio valittu, ei huomioida käyttäjän organisaation ulkopuolisia hakukohderyhmiä
       makeHakukohderyhmaQueryWithKayttooikeudet(selectedKayttooikeusOrganisaatiot, List.empty, "hh", "h")
     } else {
       makeHakukohderyhmaQueryWithKayttooikeudet(selectedKayttooikeusOrganisaatiot, kayttooikeusHakukohderyhmat, "hh", "h")

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/KkHakeneetHyvaksytytVastaanottaneetRepository.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/KkHakeneetHyvaksytytVastaanottaneetRepository.scala
@@ -1,14 +1,8 @@
 package fi.oph.ovara.backend.repository
 
-import fi.oph.ovara.backend.domain.{
-  KkHakeneetHyvaksytytVastaanottaneetHakukohteittain,
-  KkHakeneetHyvaksytytVastaanottaneetHauittainTunnisteella,
-  KkHakeneetHyvaksytytVastaanottaneetResult,
-  KkHakeneetHyvaksytytVastaanottaneetToimipisteittain,
-  KkHakeneetHyvaksytytVastaanottaneetTunnisteella
-}
+import fi.oph.ovara.backend.domain.{KkHakeneetHyvaksytytVastaanottaneetHakukohteittain, KkHakeneetHyvaksytytVastaanottaneetHauittainTunnisteella, KkHakeneetHyvaksytytVastaanottaneetResult, KkHakeneetHyvaksytytVastaanottaneetToimipisteittain, KkHakeneetHyvaksytytVastaanottaneetTunnisteella}
 import fi.oph.ovara.backend.utils.RepositoryUtils
-import fi.oph.ovara.backend.utils.RepositoryUtils.buildTutkinnonTasoFilters
+import fi.oph.ovara.backend.utils.RepositoryUtils.{buildTutkinnonTasoFilters, makeHakukohderyhmaQueryWithKayttooikeudet, makeOptionalJarjestyspaikkaQuery}
 import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.stereotype.Component
 import slick.dbio.{DBIO, Effect}
@@ -22,6 +16,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
   private def buildFilters(
       haut: List[String],
       selectedKayttooikeusOrganisaatiot: List[String],
+      isOrganisaatioRajain: Boolean,
+      kayttooikeusHakukohderyhmat: List[String],
       hakukohteet: List[String],
       hakukohderyhmat: List[String],
       okmOhjauksenAlat: List[String],
@@ -32,21 +28,12 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       ensikertalainen: Option[Boolean]
   ): String = {
 
-    val hakukohderyhmaFilter =
-      if (hakukohderyhmat.nonEmpty) {
-          s"AND (t.hakukohde_oid IN (SELECT DISTINCT hakukohde_oid FROM pub.pub_dim_hakukohderyhma_ja_hakukohteet WHERE hakukohderyhma_oid IN (${RepositoryUtils
-            .makeListOfValuesQueryStr(hakukohderyhmat)})))"
-      } else
-        ""
+    val hakukohteetOrganisaatioJaKayttooikeusrajauksillaFilter: String = buildOrganisaatioKayttooikeusFilter(selectedKayttooikeusOrganisaatiot, isOrganisaatioRajain, kayttooikeusHakukohderyhmat)
     val filters = Seq(
       s"h.haku_oid IN (${RepositoryUtils.makeListOfValuesQueryStr(haut)})",
-        RepositoryUtils.makeOptionalListOfValuesQueryStr(
-          "AND",
-          "h.jarjestyspaikka_oid",
-          selectedKayttooikeusOrganisaatiot
-        ),
+      hakukohteetOrganisaatioJaKayttooikeusrajauksillaFilter,
       RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "t.hakukohde_oid", hakukohteet),
-      hakukohderyhmaFilter,
+      RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "hh.hakukohderyhma_oid", hakukohderyhmat),
       RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.okm_ohjauksen_ala", okmOhjauksenAlat),
       RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "t.aidinkieli", aidinkielet),
       RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "t.kansalaisuusluokka", kansalaisuudet),
@@ -58,8 +45,57 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
     filters
   }
 
+  private def buildFiltersForMainQuery(
+                                        haut: List[String],
+                                        aidinkielet: List[String],
+                                        kansalaisuudet: List[String],
+                                        sukupuoli: Option[String],
+                                        ensikertalainen: Option[Boolean]
+                                      ): String = {
+    Seq(
+      s"h.haku_oid IN (${RepositoryUtils.makeListOfValuesQueryStr(haut)})",
+      RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "t.aidinkieli", aidinkielet),
+      RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "t.kansalaisuusluokka", kansalaisuudet),
+      RepositoryUtils.makeEqualsQueryStrOfOptional("AND", "t.sukupuoli", sukupuoli),
+      RepositoryUtils.makeEqualsQueryStrOfOptionalBoolean("AND", "t.ensikertalainen", ensikertalainen),
+    ).filter(_.nonEmpty).mkString("\n")
+  }
+  private def buildHakukohdeFilters(
+                                     haut: List[String],
+                                     selectedKayttooikeusOrganisaatiot: List[String],
+                                     isOrganisaatioRajain: Boolean,
+                                     kayttooikeusHakukohderyhmat: List[String],
+                                     hakukohteet: List[String],
+                                     hakukohderyhmat: List[String],
+                                     okmOhjauksenAlat: List[String],
+                                     tutkinnonTasot: List[String]
+                                   ): String = {
+    val hakukohteetOrganisaatioJaKayttooikeusrajauksillaFilter =
+      buildOrganisaatioKayttooikeusFilter(selectedKayttooikeusOrganisaatiot, isOrganisaatioRajain, kayttooikeusHakukohderyhmat)
+
+    Seq(
+      s"h.haku_oid IN (${RepositoryUtils.makeListOfValuesQueryStr(haut)})",
+      hakukohteetOrganisaatioJaKayttooikeusrajauksillaFilter,
+      RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.hakukohde_oid", hakukohteet),
+      RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "hh.hakukohderyhma_oid", hakukohderyhmat),
+      RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.okm_ohjauksen_ala", okmOhjauksenAlat),
+      buildTutkinnonTasoFilters(tutkinnonTasot, "h")
+    ).filter(_.nonEmpty).mkString("\n")
+  }
+
+  private def buildOrganisaatioKayttooikeusFilter(selectedKayttooikeusOrganisaatiot: List[String], isOrganisaatioRajain: Boolean, kayttooikeusHakukohderyhmat: List[String]) = {
+    if (isOrganisaatioRajain) {
+      // jos organisaatio valittu, ei huomioida käyttäjän organisaatio ulkopuolisia hakukohderyhmiä
+      makeHakukohderyhmaQueryWithKayttooikeudet(selectedKayttooikeusOrganisaatiot, List.empty, "hh", "h")
+    } else {
+      makeHakukohderyhmaQueryWithKayttooikeudet(selectedKayttooikeusOrganisaatiot, kayttooikeusHakukohderyhmat, "hh", "h")
+    }
+  }
+
   def selectHakukohteittainWithParams(
       selectedKayttooikeusOrganisaatiot: List[String],
+      isOrganisaatioRajain: Boolean,
+      kayttooikeusHakukohderyhmat: List[String],
       haut: List[String],
       hakukohteet: List[String],
       hakukohderyhmat: List[String],
@@ -76,6 +112,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
     val filters = buildFilters(
       haut,
       selectedKayttooikeusOrganisaatiot,
+      isOrganisaatioRajain,
+      kayttooikeusHakukohderyhmat,
       hakukohteet,
       hakukohderyhmat,
       okmOhjauksenAlat,
@@ -113,6 +151,7 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       FROM pub.pub_fct_raportti_tilastoraportti_kk_hakutoive t
       JOIN pub.pub_dim_hakukohde h ON t.hakukohde_oid = h.hakukohde_oid
       JOIN pub.pub_dim_haku ha ON h.haku_oid = ha.haku_oid
+      LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
       WHERE #$filters
       GROUP BY h.hakukohde_oid, h.hakukohde_nimi, h.haku_oid, ha.haku_nimi, h.organisaatio_nimi"""
         .as[KkHakeneetHyvaksytytVastaanottaneetHakukohteittain]
@@ -123,6 +162,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
 
   def selectHauittainWithParams(
       selectedKayttooikeusOrganisaatiot: List[String],
+      isOrganisaatioRajain: Boolean,
+      kayttooikeusHakukohderyhmat: List[String],
       haut: List[String],
       hakukohteet: List[String],
       hakukohderyhmat: List[String],
@@ -136,75 +177,87 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
     KkHakeneetHyvaksytytVastaanottaneetHauittainTunnisteella
   ], KkHakeneetHyvaksytytVastaanottaneetHauittainTunnisteella, Effect] = {
 
-    val filters = buildFilters(
+    val filters = buildFiltersForMainQuery(
       haut,
-      selectedKayttooikeusOrganisaatiot,
-      hakukohteet,
-      hakukohderyhmat,
-      okmOhjauksenAlat,
-      tutkinnonTasot,
       aidinkielet,
       kansalaisuudet,
       sukupuoli,
       ensikertalainen
     )
-    val hakukohdeHakuFilter = s"h.haku_oid IN (${RepositoryUtils.makeListOfValuesQueryStr(haut)})"
-    val hakukohdeFilter     = RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "t.hakukohde_oid", hakukohteet)
-    val hakukohdeOrganisaatioFilter = RepositoryUtils.makeOptionalListOfValuesQueryStr(
-      "AND",
-      "h.jarjestyspaikka_oid",
-      selectedKayttooikeusOrganisaatiot
+    val hakukohdeFilters = buildHakukohdeFilters(
+      haut,
+      selectedKayttooikeusOrganisaatiot,
+      isOrganisaatioRajain,
+      kayttooikeusHakukohderyhmat,
+      hakukohteet,
+      hakukohderyhmat,
+      okmOhjauksenAlat,
+      tutkinnonTasot
     )
-    val hakukohdeOkmOhjauksenalaFilter =
-      RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.okm_ohjauksen_ala", okmOhjauksenAlat)
-    val hakukohdeTutkinnontasoFilter = buildTutkinnonTasoFilters(tutkinnonTasot, "h")
 
-    val query =
-      sql"""SELECT
-        ha.haku_oid,
-        ha.haku_nimi,
-        h.organisaatio_nimi,
-        COUNT(DISTINCT t.henkilo_oid) AS hakijat,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE ensisijainen) AS ensisijaisia,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE ensikertalainen) AS ensikertalaisia,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE hyvaksytty) AS hyvaksytyt,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE vastaanottanut) AS vastaanottaneet,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE lasna) AS lasna,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE poissa) AS poissa,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE ilmoittautunut) AS ilm_yht,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE maksuvelvollinen) AS maksuvelvollisia,
-        a.valinnan_aloituspaikat,
-        a.aloituspaikat,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_1) AS toive_1,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_2) AS toive_2,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_3) AS toive_3,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_4) AS toive_4,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_5) AS toive_5,
-        COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_6) AS toive_6
+    val filteredHakukohteet = s"""WITH filtered_hakukohteet AS (
+             SELECT h.*
+             FROM pub.pub_dim_hakukohde h
+             LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh
+               ON h.hakukohde_oid = hh.hakukohde_oid
+             WHERE $hakukohdeFilters
+         )
+      """
+
+      val query =
+        sql"""#$filteredHakukohteet
+        SELECT
+          ha.haku_oid,
+          ha.haku_nimi,
+          h.organisaatio_nimi,
+          COUNT(DISTINCT t.henkilo_oid) AS hakijat,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE ensisijainen) AS ensisijaisia,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE ensikertalainen) AS ensikertalaisia,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE hyvaksytty) AS hyvaksytyt,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE vastaanottanut) AS vastaanottaneet,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE lasna) AS lasna,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE poissa) AS poissa,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE ilmoittautunut) AS ilm_yht,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE maksuvelvollinen) AS maksuvelvollisia,
+          (
+            SELECT SUM(h2.valintaperusteiden_aloituspaikat)
+            FROM (
+              SELECT DISTINCT h3.hakukohde_oid, h3.haku_oid, h3.organisaatio_nimi, h3.valintaperusteiden_aloituspaikat
+              FROM filtered_hakukohteet h3
+            ) h2
+            WHERE h2.haku_oid = ha.haku_oid AND h2.organisaatio_nimi = h.organisaatio_nimi
+          ) AS valinnan_aloituspaikat,
+
+          (
+            SELECT SUM(h2.hakukohteen_aloituspaikat)
+            FROM (
+              SELECT DISTINCT h3.hakukohde_oid, h3.haku_oid, h3.organisaatio_nimi, h3.hakukohteen_aloituspaikat
+              FROM filtered_hakukohteet h3
+            ) h2
+            WHERE h2.haku_oid = ha.haku_oid AND h2.organisaatio_nimi = h.organisaatio_nimi
+          ) AS aloituspaikat,
+
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE toive_1) AS toive_1,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE toive_2) AS toive_2,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE toive_3) AS toive_3,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE toive_4) AS toive_4,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE toive_5) AS toive_5,
+          COUNT(DISTINCT t.henkilo_oid) FILTER (WHERE toive_6) AS toive_6
         FROM pub.pub_fct_raportti_tilastoraportti_kk_hakutoive t
-        JOIN pub.pub_dim_hakukohde h ON t.hakukohde_oid = h.hakukohde_oid
+        JOIN filtered_hakukohteet h ON t.hakukohde_oid = h.hakukohde_oid
         JOIN pub.pub_dim_haku ha ON h.haku_oid = ha.haku_oid
-        JOIN (
-	      SELECT
-		    h.haku_oid,
-            SUM(h.valintaperusteiden_aloituspaikat) as valinnan_aloituspaikat,
-		    SUM(h.hakukohteen_aloituspaikat) as aloituspaikat
-	      FROM pub.pub_dim_hakukohde h
-	    WHERE #$hakukohdeHakuFilter
-        #$hakukohdeFilter
-        #$hakukohdeOrganisaatioFilter
-        #$hakukohdeOkmOhjauksenalaFilter
-        #$hakukohdeTutkinnontasoFilter
-	    group by 1) a on h.haku_oid = a.haku_oid
-    WHERE #$filters
-    GROUP BY 1, 2, 3, 13, 14""".as[KkHakeneetHyvaksytytVastaanottaneetHauittainTunnisteella]
+        WHERE #$filters
+        GROUP BY ha.haku_oid, ha.haku_nimi, h.organisaatio_nimi
+        """.as[KkHakeneetHyvaksytytVastaanottaneetHauittainTunnisteella]
 
     LOG.debug(s"selectHauittainWithParams: ${query.statements.head}")
     query
   }
-  
+
   def selectToimipisteittainWithParams(
       selectedKayttooikeusOrganisaatiot: List[String],
+      isOrganisaatioRajain: Boolean,
+      kayttooikeusHakukohderyhmat: List[String],
       haut: List[String],
       hakukohteet: List[String],
       hakukohderyhmat: List[String],
@@ -218,32 +271,36 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
     KkHakeneetHyvaksytytVastaanottaneetToimipisteittain
   ], KkHakeneetHyvaksytytVastaanottaneetToimipisteittain, Effect] = {
 
-    val filters = buildFilters(
+    val filters = buildFiltersForMainQuery(
       haut,
-      selectedKayttooikeusOrganisaatiot,
-      hakukohteet,
-      hakukohderyhmat,
-      okmOhjauksenAlat,
-      tutkinnonTasot,
       aidinkielet,
       kansalaisuudet,
       sukupuoli,
       ensikertalainen
     )
-
-    val hakukohdeHakuFilter = s"h.haku_oid IN (${RepositoryUtils.makeListOfValuesQueryStr(haut)})"
-    val hakukohdeFilter     = RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "t.hakukohde_oid", hakukohteet)
-    val hakukohdeOrganisaatioFilter = RepositoryUtils.makeOptionalListOfValuesQueryStr(
-      "AND",
-      "h.jarjestyspaikka_oid",
-      selectedKayttooikeusOrganisaatiot
+    val hakukohdeFilters = buildHakukohdeFilters(
+      haut,
+      selectedKayttooikeusOrganisaatiot,
+      isOrganisaatioRajain,
+      kayttooikeusHakukohderyhmat,
+      hakukohteet,
+      hakukohderyhmat,
+      okmOhjauksenAlat,
+      tutkinnonTasot
     )
-    val hakukohdeOkmOhjauksenalaFilter =
-      RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.okm_ohjauksen_ala", okmOhjauksenAlat)
-    val hakukohdeTutkinnontasoFilter = buildTutkinnonTasoFilters(tutkinnonTasot, "h")
+
+    val filteredHakukohteet = s"""WITH filtered_hakukohteet AS (
+             SELECT h.*
+             FROM pub.pub_dim_hakukohde h
+             LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh
+               ON h.hakukohde_oid = hh.hakukohde_oid
+             WHERE $hakukohdeFilters
+         )
+      """
 
     val query =
-      sql"""SELECT
+      sql"""#$filteredHakukohteet
+      SELECT
       h.toimipiste,
       h.organisaatio_nimi,
       COUNT(DISTINCT t.henkilo_oid) AS hakijat,
@@ -255,8 +312,22 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE poissa) AS poissa,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE ilmoittautunut) AS ilm_yht,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE maksuvelvollinen) AS maksuvelvollisia,
-      a.valinnan_aloituspaikat,
-      a.aloituspaikat,
+      (
+        SELECT SUM(h2.valintaperusteiden_aloituspaikat)
+        FROM (
+          SELECT DISTINCT h3.hakukohde_oid, h3.toimipiste, h3.organisaatio_nimi, h3.valintaperusteiden_aloituspaikat
+          FROM filtered_hakukohteet h3
+        ) h2
+        WHERE h2.toimipiste = h.toimipiste AND h2.organisaatio_nimi = h.organisaatio_nimi
+      ) AS valinnan_aloituspaikat,
+      (
+        SELECT SUM(h2.hakukohteen_aloituspaikat)
+        FROM (
+          SELECT DISTINCT h3.hakukohde_oid, h3.toimipiste, h3.organisaatio_nimi, h3.hakukohteen_aloituspaikat
+          FROM filtered_hakukohteet h3
+        ) h2
+        WHERE h2.toimipiste = h.toimipiste AND h2.organisaatio_nimi = h.organisaatio_nimi
+      ) AS aloituspaikat,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_1) AS toive_1,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_2) AS toive_2,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_3) AS toive_3,
@@ -264,27 +335,17 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_5) AS toive_5,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_6) AS toive_6
       FROM pub.pub_fct_raportti_tilastoraportti_kk_hakutoive t
-      JOIN pub.pub_dim_hakukohde h ON t.hakukohde_oid = h.hakukohde_oid
-      JOIN (
-	    SELECT
-		  h.toimipiste,
-          SUM(h.valintaperusteiden_aloituspaikat) as valinnan_aloituspaikat,
-		  SUM(h.hakukohteen_aloituspaikat) as aloituspaikat
-	    FROM pub.pub_dim_hakukohde h
-	    WHERE #$hakukohdeHakuFilter
-        #$hakukohdeFilter
-        #$hakukohdeOrganisaatioFilter
-        #$hakukohdeOkmOhjauksenalaFilter
-        #$hakukohdeTutkinnontasoFilter
-	    GROUP BY  1) a ON h.toimipiste = a.toimipiste
+      JOIN filtered_hakukohteet h ON t.hakukohde_oid = h.hakukohde_oid
       WHERE #$filters
-      GROUP BY 1, 2, 12, 13""".as[KkHakeneetHyvaksytytVastaanottaneetToimipisteittain]
+      GROUP BY h.toimipiste, h.organisaatio_nimi""".as[KkHakeneetHyvaksytytVastaanottaneetToimipisteittain]
     LOG.debug(s"selectToimipisteittainWithParams: ${query.statements.head}")
     query
   }
 
   def selectOrganisaatioittainWithParams(
       selectedKayttooikeusOrganisaatiot: List[String],
+      isOrganisaatioRajain: Boolean,
+      kayttooikeusHakukohderyhmat: List[String],
       haut: List[String],
       hakukohteet: List[String],
       hakukohderyhmat: List[String],
@@ -302,6 +363,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
     val filters = buildFilters(
       haut,
       selectedKayttooikeusOrganisaatiot,
+      isOrganisaatioRajain,
+      kayttooikeusHakukohderyhmat,
       hakukohteet,
       hakukohderyhmat,
       okmOhjauksenAlat,
@@ -319,6 +382,11 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       "h.jarjestyspaikka_oid",
       selectedKayttooikeusOrganisaatiot
     )
+    val hakukohdeHakukohderyhmafilter = RepositoryUtils.makeOptionalListOfValuesQueryStr(
+      "AND",
+      "hh.hakukohderyhma_oid",
+      hakukohderyhmat
+    )
     val hakukohdeOkmOhjauksenalaFilter =
       RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.okm_ohjauksen_ala", okmOhjauksenAlat)
     val hakukohdeTutkinnontasoFilter = buildTutkinnonTasoFilters(tutkinnonTasot, "h")
@@ -328,8 +396,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       case _                   => "h.koulutustoimija as tunniste, h.koulutustoimija_nimi as otsikko"
     }
     val organisaatioJoin = organisaatiotaso match {
-      case "oppilaitoksittain" => "h.oppilaitos = a.oppilaitos"
-      case _                   => "h.koulutustoimija = a.koulutustoimija"
+      case "oppilaitoksittain" => "h.oppilaitos = aloituspaikatQuery.oppilaitos"
+      case _                   => "h.koulutustoimija = aloituspaikatQuery.koulutustoimija"
     }
     val organisaatio = organisaatiotaso match {
       case "oppilaitoksittain" => "h.oppilaitos"
@@ -347,8 +415,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE poissa) AS poissa,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE ilmoittautunut) AS ilm_yht,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE maksuvelvollinen) AS maksuvelvollisia,
-      a.valinnan_aloituspaikat,
-      a.aloituspaikat,
+      aloituspaikatQuery.valinnan_aloituspaikat,
+      aloituspaikatQuery.aloituspaikat,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_1) AS toive_1,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_2) AS toive_2,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_3) AS toive_3,
@@ -357,6 +425,7 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_6) AS toive_6
       FROM pub.pub_fct_raportti_tilastoraportti_kk_hakutoive t
       JOIN pub.pub_dim_hakukohde h ON t.hakukohde_oid = h.hakukohde_oid
+      LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
       JOIN (
 	    SELECT
 		  #$organisaatio,
@@ -366,19 +435,22 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
 	    WHERE #$hakukohdeHakuFilter
         #$hakukohdeFilter
         #$hakukohdeOrganisaatioFilter
+        #$hakukohdeHakukohderyhmafilter
         #$hakukohdeOkmOhjauksenalaFilter
         #$hakukohdeTutkinnontasoFilter
-	    GROUP BY  1) a ON #$organisaatioJoin
+	    GROUP BY  1) aloituspaikatQuery ON #$organisaatioJoin
       WHERE #$filters
       GROUP BY 1, 2, 12, 13""".as[KkHakeneetHyvaksytytVastaanottaneetTunnisteella]
 
     LOG.debug(s"selectOrganisaatioittainWithParams: ${query.statements.head}")
     query
   }
-  
+
 
   def selectOkmOhjauksenAloittainWithParams(
       selectedKayttooikeusOrganisaatiot: List[String],
+      isOrganisaatioRajain: Boolean,
+      kayttooikeusHakukohderyhmat: List[String],
       haut: List[String],
       hakukohteet: List[String],
       hakukohderyhmat: List[String],
@@ -395,6 +467,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
     val filters = buildFilters(
       haut,
       selectedKayttooikeusOrganisaatiot,
+      isOrganisaatioRajain,
+      kayttooikeusHakukohderyhmat,
       hakukohteet,
       hakukohderyhmat,
       okmOhjauksenAlat,
@@ -411,6 +485,11 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       "AND",
       "h.jarjestyspaikka_oid",
       selectedKayttooikeusOrganisaatiot
+    )
+    val hakukohdeHakukohderyhmafilter = RepositoryUtils.makeOptionalListOfValuesQueryStr(
+      "AND",
+      "hh.hakukohderyhma_oid",
+      hakukohderyhmat
     )
     val hakukohdeOkmOhjauksenalaFilter =
       RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.okm_ohjauksen_ala", okmOhjauksenAlat)
@@ -429,8 +508,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE poissa) AS poissa,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE ilmoittautunut) AS ilm_yht,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE maksuvelvollinen) AS maksuvelvollisia,
-      a.valinnan_aloituspaikat,
-      a.aloituspaikat,
+      aloituspaikatQuery.valinnan_aloituspaikat,
+      aloituspaikatQuery.aloituspaikat,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_1) AS toive_1,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_2) AS toive_2,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_3) AS toive_3,
@@ -440,6 +519,7 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       FROM pub.pub_fct_raportti_tilastoraportti_kk_hakutoive t
       JOIN pub.pub_dim_hakukohde h ON t.hakukohde_oid = h.hakukohde_oid
       JOIN pub.pub_dim_koodisto_okmohjauksenala o ON h.okm_ohjauksen_ala = o.koodiarvo
+      LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
       JOIN (
 	    SELECT
 		  h.okm_ohjauksen_ala,
@@ -449,18 +529,21 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
 	    WHERE #$hakukohdeHakuFilter
         #$hakukohdeFilter
         #$hakukohdeOrganisaatioFilter
+        #$hakukohdeHakukohderyhmafilter
         #$hakukohdeOkmOhjauksenalaFilter
         #$hakukohdeTutkinnontasoFilter
-	    GROUP BY  1) a ON h.okm_ohjauksen_ala = a.okm_ohjauksen_ala
+	    GROUP BY  1) aloituspaikatQuery ON h.okm_ohjauksen_ala = aloituspaikatQuery.okm_ohjauksen_ala
       WHERE #$filters
       GROUP BY 1, 2, 12, 13""".as[KkHakeneetHyvaksytytVastaanottaneetTunnisteella]
 
     LOG.debug(s"selectOkmOhjauksenAloittainWithParams: ${query.statements.head}")
     query
   }
-  
+
   def selectKansalaisuuksittainWithParams(
       selectedKayttooikeusOrganisaatiot: List[String],
+      isOrganisaatioRajain: Boolean,
+      kayttooikeusHakukohderyhmat: List[String],
       haut: List[String],
       hakukohteet: List[String],
       hakukohderyhmat: List[String],
@@ -477,6 +560,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
     val filters = buildFilters(
       haut,
       selectedKayttooikeusOrganisaatiot,
+      isOrganisaatioRajain,
+      kayttooikeusHakukohderyhmat,
       hakukohteet,
       hakukohderyhmat,
       okmOhjauksenAlat,
@@ -510,16 +595,19 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       FROM pub.pub_fct_raportti_tilastoraportti_kk_hakutoive t
       JOIN pub.pub_dim_hakukohde h ON t.hakukohde_oid = h.hakukohde_oid
       JOIN pub.pub_dim_koodisto_maa_2 m ON t.kansalaisuus = m.koodiarvo
+      LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
       WHERE #$filters
       GROUP BY 1, 11, 12""".as[KkHakeneetHyvaksytytVastaanottaneetResult]
 
     LOG.debug(s"selectKansalaisuuksittainWithParams: ${query.statements.head}")
     query
   }
-  
+
 
   def selectHakukohderyhmittainWithParams(
       selectedKayttooikeusOrganisaatiot: List[String],
+      isOrganisaatioRajain: Boolean,
+      kayttooikeusHakukohderyhmat: List[String],
       haut: List[String],
       hakukohteet: List[String],
       hakukohderyhmat: List[String],
@@ -536,6 +624,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
     val filters = buildFilters(
       haut,
       selectedKayttooikeusOrganisaatiot,
+      isOrganisaatioRajain,
+      kayttooikeusHakukohderyhmat,
       hakukohteet,
       hakukohderyhmat,
       okmOhjauksenAlat,
@@ -551,6 +641,11 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       "AND",
       "h.jarjestyspaikka_oid",
       selectedKayttooikeusOrganisaatiot
+    )
+    val hakukohdeHakukohderyhmafilter = RepositoryUtils.makeOptionalListOfValuesQueryStr(
+      "AND",
+      "hh.hakukohderyhma_oid",
+      hakukohderyhmat
     )
     val hakukohdeOkmOhjauksenalaFilter =
       RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.okm_ohjauksen_ala", okmOhjauksenAlat)
@@ -569,8 +664,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE poissa) AS poissa,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE ilmoittautunut) AS ilm_yht,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE maksuvelvollinen) AS maksuvelvollisia,
-      a.valinnan_aloituspaikat,
-      a.aloituspaikat,
+      aloituspaikatQuery.valinnan_aloituspaikat,
+      aloituspaikatQuery.aloituspaikat,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_1) AS toive_1,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_2) AS toive_2,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_3) AS toive_3,
@@ -579,7 +674,7 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_6) AS toive_6
       FROM pub.pub_fct_raportti_tilastoraportti_kk_hakutoive t
       JOIN pub.pub_dim_hakukohde h ON t.hakukohde_oid = h.hakukohde_oid
-      JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
+      LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
       JOIN pub.pub_dim_hakukohderyhma hr ON hh.hakukohderyhma_oid = hr.hakukohderyhma_oid
       JOIN (
 	    SELECT
@@ -587,23 +682,27 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
           SUM(h.valintaperusteiden_aloituspaikat) as valinnan_aloituspaikat,
 		  SUM(h.hakukohteen_aloituspaikat) as aloituspaikat
 	    FROM pub.pub_dim_hakukohde h
-        JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
+        LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
 	    WHERE #$hakukohdeHakuFilter
         #$hakukohdeFilter
         #$hakukohdeOrganisaatioFilter
+        #$hakukohdeHakukohderyhmafilter
         #$hakukohdeOkmOhjauksenalaFilter
         #$hakukohdeTutkinnontasoFilter
-	    GROUP BY  1) a ON hr.hakukohderyhma_oid = a.hakukohderyhma_oid
+        #$hakukohdeHakukohderyhmafilter
+	    GROUP BY  1) aloituspaikatQuery ON hr.hakukohderyhma_oid = aloituspaikatQuery.hakukohderyhma_oid
       WHERE #$filters
       GROUP BY 1, 2, 12, 13""".as[KkHakeneetHyvaksytytVastaanottaneetTunnisteella]
 
     LOG.debug(s"selectHakukohderyhmittainWithParams: ${query.statements.head}")
     query
   }
-  
+
 
   def selectHakijatYhteensaWithParams(
       selectedKayttooikeusOrganisaatiot: List[String],
+      isOrganisaatioRajain: Boolean,
+      kayttooikeusHakukohderyhmat: List[String],
       haut: List[String],
       hakukohteet: List[String],
       hakukohderyhmat: List[String],
@@ -621,9 +720,12 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
             .makeListOfValuesQueryStr(hakukohderyhmat)})))"
       } else
         ""
+
+    val hakukohteetOrganisaatioJaKayttooikeusrajauksillaFilter: String = buildOrganisaatioKayttooikeusFilter(selectedKayttooikeusOrganisaatiot, isOrganisaatioRajain, kayttooikeusHakukohderyhmat)
+
     val filters = Seq(
       s"ht.haku_oid IN (${RepositoryUtils.makeListOfValuesQueryStr(haut)})",
-      RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.jarjestyspaikka_oid", selectedKayttooikeusOrganisaatiot),
+      hakukohteetOrganisaatioJaKayttooikeusrajauksillaFilter,
       RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "ht.hakukohde_oid", hakukohteet),
       hakukohderyhmaFilter,
       RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.okm_ohjauksen_ala", okmOhjauksenAlat),
@@ -644,6 +746,7 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       sql"""SELECT count(distinct ht.henkilo_oid)
       FROM pub.pub_dim_hakutoive ht
       JOIN pub.pub_dim_hakukohde h ON ht.hakukohde_oid = h.hakukohde_oid
+      JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
       JOIN pub.pub_dim_henkilo he on ht.henkilo_hakemus_id = he.henkilo_hakemus_id
       #$maksuvelvollisuusJoin
       WHERE #$filters

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/KkHakeneetHyvaksytytVastaanottaneetRepository.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/KkHakeneetHyvaksytytVastaanottaneetRepository.scala
@@ -612,7 +612,14 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
     KkHakeneetHyvaksytytVastaanottaneetTunnisteella
   ], KkHakeneetHyvaksytytVastaanottaneetTunnisteella, Effect] = {
 
-    val filters = buildFilters(
+    val filters = buildFiltersForMainQuery(
+      haut,
+      aidinkielet,
+      kansalaisuudet,
+      sukupuoli,
+      ensikertalainen
+    )
+    val hakukohdeFilters = buildHakukohdeFilters(
       haut,
       selectedKayttooikeusOrganisaatiot,
       isOrganisaatioRajain,
@@ -620,30 +627,22 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       hakukohteet,
       hakukohderyhmat,
       okmOhjauksenAlat,
-      tutkinnonTasot,
-      aidinkielet,
-      kansalaisuudet,
-      sukupuoli,
-      ensikertalainen
+      tutkinnonTasot
     )
-    val hakukohdeHakuFilter = s"h.haku_oid IN (${RepositoryUtils.makeListOfValuesQueryStr(haut)})"
-    val hakukohdeFilter     = RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "t.hakukohde_oid", hakukohteet)
-    val hakukohdeOrganisaatioFilter = RepositoryUtils.makeOptionalListOfValuesQueryStr(
-      "AND",
-      "h.jarjestyspaikka_oid",
-      selectedKayttooikeusOrganisaatiot
-    )
-    val hakukohdeHakukohderyhmafilter = RepositoryUtils.makeOptionalListOfValuesQueryStr(
-      "AND",
-      "hh.hakukohderyhma_oid",
-      hakukohderyhmat
-    )
-    val hakukohdeOkmOhjauksenalaFilter =
-      RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "h.okm_ohjauksen_ala", okmOhjauksenAlat)
-    val hakukohdeTutkinnontasoFilter = buildTutkinnonTasoFilters(tutkinnonTasot, "h")
+
+    val filteredHakukohteet = s"""WITH filtered_hakukohteet AS (
+             SELECT h.*, hh.hakukohderyhma_oid
+             FROM pub.pub_dim_hakukohde h
+             LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh
+               ON h.hakukohde_oid = hh.hakukohde_oid
+             WHERE $hakukohdeFilters
+         )
+      """
 
     val query =
-      sql"""SELECT
+      sql"""
+      #$filteredHakukohteet
+      SELECT
       hr.hakukohderyhma_oid AS tunniste,
       hr.hakukohderyhma_nimi AS otsikko,
       COUNT(DISTINCT t.henkilo_oid) AS hakijat,
@@ -655,8 +654,22 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE poissa) AS poissa,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE ilmoittautunut) AS ilm_yht,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE maksuvelvollinen) AS maksuvelvollisia,
-      aloituspaikatQuery.valinnan_aloituspaikat,
-      aloituspaikatQuery.aloituspaikat,
+      (
+        SELECT SUM(h2.valintaperusteiden_aloituspaikat)
+        FROM (
+          SELECT DISTINCT h3.hakukohde_oid, h3.hakukohderyhma_oid, h3.valintaperusteiden_aloituspaikat
+          FROM filtered_hakukohteet h3
+        ) h2
+        WHERE h2.hakukohderyhma_oid = hr.hakukohderyhma_oid
+      ) AS valinnan_aloituspaikat,
+      (
+        SELECT SUM(h2.hakukohteen_aloituspaikat)
+        FROM (
+          SELECT DISTINCT h3.hakukohde_oid, h3.hakukohderyhma_oid, h3.hakukohteen_aloituspaikat
+          FROM filtered_hakukohteet h3
+        ) h2
+        WHERE h2.hakukohderyhma_oid = hr.hakukohderyhma_oid
+      ) AS aloituspaikat,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_1) AS toive_1,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_2) AS toive_2,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_3) AS toive_3,
@@ -664,24 +677,8 @@ class KkHakeneetHyvaksytytVastaanottaneetRepository extends Extractors {
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_5) AS toive_5,
       COUNT(DISTINCT t.henkilo_oid) filter (WHERE toive_6) AS toive_6
       FROM pub.pub_fct_raportti_tilastoraportti_kk_hakutoive t
-      JOIN pub.pub_dim_hakukohde h ON t.hakukohde_oid = h.hakukohde_oid
-      LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
-      JOIN pub.pub_dim_hakukohderyhma hr ON hh.hakukohderyhma_oid = hr.hakukohderyhma_oid
-      JOIN (
-	    SELECT
-		  hh.hakukohderyhma_oid,
-          SUM(h.valintaperusteiden_aloituspaikat) as valinnan_aloituspaikat,
-		  SUM(h.hakukohteen_aloituspaikat) as aloituspaikat
-	    FROM pub.pub_dim_hakukohde h
-        LEFT JOIN pub.pub_dim_hakukohderyhma_ja_hakukohteet hh ON h.hakukohde_oid = hh.hakukohde_oid
-	    WHERE #$hakukohdeHakuFilter
-        #$hakukohdeFilter
-        #$hakukohdeOrganisaatioFilter
-        #$hakukohdeHakukohderyhmafilter
-        #$hakukohdeOkmOhjauksenalaFilter
-        #$hakukohdeTutkinnontasoFilter
-        #$hakukohdeHakukohderyhmafilter
-	    GROUP BY  1) aloituspaikatQuery ON hr.hakukohderyhma_oid = aloituspaikatQuery.hakukohderyhma_oid
+      JOIN filtered_hakukohteet h ON t.hakukohde_oid = h.hakukohde_oid
+      JOIN pub.pub_dim_hakukohderyhma hr ON h.hakukohderyhma_oid = hr.hakukohderyhma_oid
       WHERE #$filters
       GROUP BY 1, 2, 12, 13""".as[KkHakeneetHyvaksytytVastaanottaneetTunnisteella]
 

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/KkHakeneetHyvaksytytVastaanottaneetRepository.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/KkHakeneetHyvaksytytVastaanottaneetRepository.scala
@@ -2,7 +2,7 @@ package fi.oph.ovara.backend.repository
 
 import fi.oph.ovara.backend.domain.{KkHakeneetHyvaksytytVastaanottaneetHakukohteittain, KkHakeneetHyvaksytytVastaanottaneetHauittainTunnisteella, KkHakeneetHyvaksytytVastaanottaneetResult, KkHakeneetHyvaksytytVastaanottaneetToimipisteittain, KkHakeneetHyvaksytytVastaanottaneetTunnisteella}
 import fi.oph.ovara.backend.utils.RepositoryUtils
-import fi.oph.ovara.backend.utils.RepositoryUtils.{buildTutkinnonTasoFilters, makeHakukohderyhmaQueryWithKayttooikeudet, makeOptionalJarjestyspaikkaQuery}
+import fi.oph.ovara.backend.utils.RepositoryUtils.{buildTutkinnonTasoFilters, makeHakukohderyhmaQueryWithKayttooikeudet}
 import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.stereotype.Component
 import slick.dbio.{DBIO, Effect}

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/CommonService.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/CommonService.scala
@@ -82,7 +82,6 @@ class CommonService(commonRepository: CommonRepository, userService: UserService
       getAllowedOrgOidsFromOrgSelection(kayttooikeusOrganisaatiot, oppilaitokset, toimipisteet, koulutustoimija)
     val isOrganisaatioRajain        = (koulutustoimija.isDefined || oppilaitokset.nonEmpty || toimipisteet.nonEmpty) && allowedOrgOidsFromSelection.nonEmpty
     val kayttooikeusHakukohderyhmat = AuthoritiesUtil.filterHakukohderyhmaOids(kayttooikeusOrganisaatiot)
-
     Try {
       db.run(
         commonRepository
@@ -428,6 +427,7 @@ class CommonService(commonRepository: CommonRepository, userService: UserService
       } else if (koulutustoimijaOid.isDefined) {
         getKoulutustoimijahierarkia(List(koulutustoimijaOid.get))
       } else {
+        LOG.info("Fetching organisaatio hierarkiat with user rights")
         getOrganisaatioHierarkiatWithUserRights match {
           case Right(hierarkiat) => hierarkiat
           case Left(error) =>

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/CommonService.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/CommonService.scala
@@ -80,7 +80,7 @@ class CommonService(commonRepository: CommonRepository, userService: UserService
 
     val allowedOrgOidsFromSelection =
       getAllowedOrgOidsFromOrgSelection(kayttooikeusOrganisaatiot, oppilaitokset, toimipisteet, koulutustoimija)
-    val isOrganisaatioRajain        = koulutustoimija.isDefined || oppilaitokset.nonEmpty || toimipisteet.nonEmpty
+    val isOrganisaatioRajain        = (koulutustoimija.isDefined || oppilaitokset.nonEmpty || toimipisteet.nonEmpty) && allowedOrgOidsFromSelection.nonEmpty
     val kayttooikeusHakukohderyhmat = AuthoritiesUtil.filterHakukohderyhmaOids(kayttooikeusOrganisaatiot)
 
     Try {

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/KkHakeneetHyvaksytytVastaanottaneetService.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/KkHakeneetHyvaksytytVastaanottaneetService.scala
@@ -56,21 +56,17 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
         oppilaitosOids = oppilaitokset,
         koulutustoimijaOid = koulutustoimija
       )
-
-      val hakukohderyhmarajaus =
-        if (orgOidsForQuery.isEmpty && hakukohderyhmat.isEmpty && !isOphPaakayttaja) {
-          // pakotetaan käyttöoikeuksien mukainen hakukohderyhmärajaus jos ei ole mitään organisaatiorajausta eikä ole pääkäyttäjä
-          kayttooikeusHakukohderyhmat
-        } else
-          hakukohderyhmat
-
+      val isOrganisaatioRajain =  (koulutustoimija.isDefined || oppilaitokset.nonEmpty || toimipisteet.nonEmpty) && orgOidsForQuery.nonEmpty
+      LOG.info(s"isOrganisaatioRajain: $isOrganisaatioRajain")
       val queryResult = tulostustapa match
         case "hauittain" =>
             val query = kkHakeneetHyvaksytytVastaanottaneetRepository.selectHauittainWithParams(
               selectedKayttooikeusOrganisaatiot = orgOidsForQuery,
+              isOrganisaatioRajain = isOrganisaatioRajain,
+              kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
               haut = haut,
               hakukohteet = hakukohteet,
-              hakukohderyhmat = hakukohderyhmarajaus,
+              hakukohderyhmat = hakukohderyhmat,
               okmOhjauksenAlat = okmOhjauksenAlat,
               tutkinnonTasot = tutkinnonTasot,
               aidinkielet = aidinkielet,
@@ -84,9 +80,11 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
         case "hakukohteittain" =>
             val query = kkHakeneetHyvaksytytVastaanottaneetRepository.selectHakukohteittainWithParams(
               selectedKayttooikeusOrganisaatiot = orgOidsForQuery,
+              isOrganisaatioRajain = isOrganisaatioRajain,
+              kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
               haut = haut,
               hakukohteet = hakukohteet,
-              hakukohderyhmat = hakukohderyhmarajaus,
+              hakukohderyhmat = hakukohderyhmat,
               okmOhjauksenAlat = okmOhjauksenAlat,
               tutkinnonTasot = tutkinnonTasot,
               aidinkielet = aidinkielet,
@@ -98,9 +96,11 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
         case "toimipisteittain" =>
             val query = kkHakeneetHyvaksytytVastaanottaneetRepository.selectToimipisteittainWithParams(
               selectedKayttooikeusOrganisaatiot = orgOidsForQuery,
+              isOrganisaatioRajain = isOrganisaatioRajain,
+              kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
               haut = haut,
               hakukohteet = hakukohteet,
-              hakukohderyhmat = hakukohderyhmarajaus,
+              hakukohderyhmat = hakukohderyhmat,
               okmOhjauksenAlat = okmOhjauksenAlat,
               tutkinnonTasot = tutkinnonTasot,
               aidinkielet = aidinkielet,
@@ -113,9 +113,11 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
         case "okm-ohjauksen-aloittain" =>
             val query = kkHakeneetHyvaksytytVastaanottaneetRepository.selectOkmOhjauksenAloittainWithParams(
               selectedKayttooikeusOrganisaatiot = orgOidsForQuery,
+              isOrganisaatioRajain = isOrganisaatioRajain,
+              kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
               haut = haut,
               hakukohteet = hakukohteet,
-              hakukohderyhmat = hakukohderyhmarajaus,
+              hakukohderyhmat = hakukohderyhmat,
               okmOhjauksenAlat = okmOhjauksenAlat,
               tutkinnonTasot = tutkinnonTasot,
               aidinkielet = aidinkielet,
@@ -128,9 +130,11 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
         case "kansalaisuuksittain" =>
             val query = kkHakeneetHyvaksytytVastaanottaneetRepository.selectKansalaisuuksittainWithParams(
               selectedKayttooikeusOrganisaatiot = orgOidsForQuery,
+              isOrganisaatioRajain = isOrganisaatioRajain,
+              kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
               haut = haut,
               hakukohteet = hakukohteet,
-              hakukohderyhmat = hakukohderyhmarajaus,
+              hakukohderyhmat = hakukohderyhmat,
               okmOhjauksenAlat = okmOhjauksenAlat,
               tutkinnonTasot = tutkinnonTasot,
               aidinkielet = aidinkielet,
@@ -142,9 +146,11 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
         case "hakukohderyhmittain" =>
             val query = kkHakeneetHyvaksytytVastaanottaneetRepository.selectHakukohderyhmittainWithParams(
               selectedKayttooikeusOrganisaatiot = orgOidsForQuery,
+              isOrganisaatioRajain = isOrganisaatioRajain,
+              kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
               haut = haut,
               hakukohteet = hakukohteet,
-              hakukohderyhmat = hakukohderyhmarajaus,
+              hakukohderyhmat = hakukohderyhmat,
               okmOhjauksenAlat = okmOhjauksenAlat,
               tutkinnonTasot = tutkinnonTasot,
               aidinkielet = aidinkielet,
@@ -157,9 +163,11 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
         case _ =>
             val query = kkHakeneetHyvaksytytVastaanottaneetRepository.selectOrganisaatioittainWithParams(
               selectedKayttooikeusOrganisaatiot = orgOidsForQuery,
+              isOrganisaatioRajain = isOrganisaatioRajain,
+              kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
               haut = haut,
               hakukohteet = hakukohteet,
-              hakukohderyhmat = hakukohderyhmarajaus,
+              hakukohderyhmat = hakukohderyhmat,
               okmOhjauksenAlat = okmOhjauksenAlat,
               tutkinnonTasot = tutkinnonTasot,
               aidinkielet = aidinkielet,
@@ -175,9 +183,11 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
       val vainEnsikertalaiset = ensikertalainen.getOrElse(false)
       val sumQuery = kkHakeneetHyvaksytytVastaanottaneetRepository.selectHakijatYhteensaWithParams(
         selectedKayttooikeusOrganisaatiot = orgOidsForQuery,
+        isOrganisaatioRajain = isOrganisaatioRajain,
+        kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
         haut = haut,
         hakukohteet = hakukohteet,
-        hakukohderyhmat = hakukohderyhmarajaus,
+        hakukohderyhmat = hakukohderyhmat,
         okmOhjauksenAlat = okmOhjauksenAlat,
         tutkinnonTasot = tutkinnonTasot,
         aidinkielet = aidinkielet,
@@ -188,9 +198,11 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
 
       val ensikertalaisetSumQuery = kkHakeneetHyvaksytytVastaanottaneetRepository.selectHakijatYhteensaWithParams(
         selectedKayttooikeusOrganisaatiot = orgOidsForQuery,
+        isOrganisaatioRajain = isOrganisaatioRajain,
+        kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
         haut = haut,
         hakukohteet = hakukohteet,
-        hakukohderyhmat = hakukohderyhmarajaus,
+        hakukohderyhmat = hakukohderyhmat,
         okmOhjauksenAlat = okmOhjauksenAlat,
         tutkinnonTasot = tutkinnonTasot,
         aidinkielet = aidinkielet,
@@ -201,9 +213,11 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
 
       val maksuvelvollisetSumQuery = kkHakeneetHyvaksytytVastaanottaneetRepository.selectHakijatYhteensaWithParams(
         selectedKayttooikeusOrganisaatiot = orgOidsForQuery,
+        isOrganisaatioRajain = isOrganisaatioRajain,
+        kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
         haut = haut,
         hakukohteet = hakukohteet,
-        hakukohderyhmat = hakukohderyhmarajaus,
+        hakukohderyhmat = hakukohderyhmat,
         okmOhjauksenAlat = okmOhjauksenAlat,
         tutkinnonTasot = tutkinnonTasot,
         aidinkielet = aidinkielet,

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/KkHakeneetHyvaksytytVastaanottaneetService.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/KkHakeneetHyvaksytytVastaanottaneetService.scala
@@ -48,7 +48,6 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
       val kayttooikeusOrganisaatiot = AuthoritiesUtil.getKayttooikeusOids(authorities)
       val kayttooikeusHakukohderyhmat = AuthoritiesUtil.filterHakukohderyhmaOids(kayttooikeusOrganisaatiot)
       val translations = lokalisointiService.getOvaraTranslations(asiointikieli)
-      val isOphPaakayttaja = AuthoritiesUtil.hasOPHPaakayttajaRights(kayttooikeusOrganisaatiot)
 
       val orgOidsForQuery = commonService.getAllowedOrgOidsFromOrgSelection(
         kayttooikeusOrganisaatioOids = kayttooikeusOrganisaatiot,
@@ -57,7 +56,6 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
         koulutustoimijaOid = koulutustoimija
       )
       val isOrganisaatioRajain =  (koulutustoimija.isDefined || oppilaitokset.nonEmpty || toimipisteet.nonEmpty) && orgOidsForQuery.nonEmpty
-      LOG.info(s"isOrganisaatioRajain: $isOrganisaatioRajain")
       val queryResult = tulostustapa match
         case "hauittain" =>
             val query = kkHakeneetHyvaksytytVastaanottaneetRepository.selectHauittainWithParams(

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/KkHakeneetHyvaksytytVastaanottaneetService.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/KkHakeneetHyvaksytytVastaanottaneetService.scala
@@ -46,6 +46,7 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
       val asiointikieli = user.asiointikieli.getOrElse("fi")
       val authorities = user.authorities
       val kayttooikeusOrganisaatiot = AuthoritiesUtil.getKayttooikeusOids(authorities)
+      val kayttooikeusHakukohderyhmat = AuthoritiesUtil.filterHakukohderyhmaOids(kayttooikeusOrganisaatiot)
       val translations = lokalisointiService.getOvaraTranslations(asiointikieli)
       val isOphPaakayttaja = AuthoritiesUtil.hasOPHPaakayttajaRights(kayttooikeusOrganisaatiot)
 
@@ -59,7 +60,7 @@ class KkHakeneetHyvaksytytVastaanottaneetService(
       val hakukohderyhmarajaus =
         if (orgOidsForQuery.isEmpty && hakukohderyhmat.isEmpty && !isOphPaakayttaja) {
           // pakotetaan käyttöoikeuksien mukainen hakukohderyhmärajaus jos ei ole mitään organisaatiorajausta eikä ole pääkäyttäjä
-          kayttooikeusOrganisaatiot
+          kayttooikeusHakukohderyhmat
         } else
           hakukohderyhmat
 

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/KkHakijatService.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/KkHakijatService.scala
@@ -45,6 +45,7 @@ class KkHakijatService(
 
     val authorities               = user.authorities
     val kayttooikeusOrganisaatiot = AuthoritiesUtil.getKayttooikeusOids(authorities)
+    val kayttooikeusHakukohderyhmat = AuthoritiesUtil.filterHakukohderyhmaOids(kayttooikeusOrganisaatiot)
     val isOphPaakayttaja          = AuthoritiesUtil.hasOPHPaakayttajaRights(kayttooikeusOrganisaatiot)
 
     val orgOidsForQuery = commonService.getAllowedOrgOidsFromOrgSelection(
@@ -52,18 +53,15 @@ class KkHakijatService(
       toimipisteOids = toimipisteet,
       oppilaitosOids = oppilaitokset
     )
-
-    val allowedHakukohderyhmat = if (isOphPaakayttaja) {
-      hakukohderyhmat
-    } else {
-      kayttooikeusOrganisaatiot intersect hakukohderyhmat
-    }
+    val isOrganisaatioRajain = (oppilaitokset.nonEmpty || toimipisteet.nonEmpty) && orgOidsForQuery.nonEmpty
 
     Try {
       val queryResult = db.run(
         kkHakijatRepository.selectWithParams(
           kayttooikeusOrganisaatiot = orgOidsForQuery,
-          hakukohderyhmat = allowedHakukohderyhmat,
+          isOrganisaatioRajain = isOrganisaatioRajain,
+          kayttooikeusHakukohderyhmat = kayttooikeusHakukohderyhmat,
+          hakukohderyhmat = hakukohderyhmat,
           haut = haut,
           oppilaitokset = oppilaitokset,
           toimipisteet = toimipisteet,

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/AuthoritiesUtil.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/AuthoritiesUtil.scala
@@ -22,5 +22,10 @@ object AuthoritiesUtil {
   def hasOPHPaakayttajaRights(kayttooikeusOrganisaatiot: List[String]): Boolean = {
     kayttooikeusOrganisaatiot.contains(OPH_PAAKAYTTAJA_OID)
   }
+
+  def filterHakukohderyhmaOids(kayttooikeusOids: List[String]): List[String] = {
+    val regex = """^1\.2\.246\.562\.28.*""".r
+    kayttooikeusOids.filter(oid => regex.matches(oid))
+  }
   
 }

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/OrganisaatioUtils.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/OrganisaatioUtils.scala
@@ -44,11 +44,7 @@ object OrganisaatioUtils {
   def getDescendantOids(hierarkia: OrganisaatioHierarkia): List[String] = {
     val organisaatioOid = hierarkia.organisaatio_oid
     val children        = hierarkia.children
-    if (children.isEmpty) {
-      List(organisaatioOid)
-    } else {
-      List(organisaatioOid) ::: children.flatMap(child => getDescendantOids(child))
-    }
+    organisaatioOid +: children.flatMap(child => getDescendantOids(child))
   }
 
   def getKayttooikeusDescendantAndSelfOids(
@@ -70,7 +66,7 @@ object OrganisaatioUtils {
   def filterActiveOrgsWithoutPeruskoulu(hierarkia: OrganisaatioHierarkia): Option[OrganisaatioHierarkia] = {
     val children = hierarkia.children
 
-    if (hierarkia.tila != "AKTIIVINEN" || 
+    if (hierarkia.tila != "AKTIIVINEN" ||
       hierarkia.oppilaitostyyppi.contains("oppilaitostyyppi_11#1") ||
       hierarkia.oppilaitostyyppi.contains("oppilaitostyyppi_12#1")) {
       None

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/RepositoryUtils.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/RepositoryUtils.scala
@@ -194,31 +194,27 @@ object RepositoryUtils {
       // poikkeustapaus missä ei-pääkäyttäjällä on oikeudet vain hakukohderyhmiin, ei organisaatioita
       if (selectedHakukohderyhmat.nonEmpty) selectedHakukohderyhmatQuery
       else kayttooikeusHakukohderyhmatQuery
-    } else {
+    } else if (isOrganisaatioRajain && selectedHakukohderyhmat.nonEmpty) {
       // ei-pääkäyttäjä, organisaatioita rajattu valikosta
-      if (isOrganisaatioRajain && selectedHakukohderyhmat.nonEmpty) {
-        s"$orgsQuery $selectedHakukohderyhmatQuery".trim
-      } else if (isOrganisaatioRajain && selectedHakukohderyhmat.isEmpty) {
-        orgsQuery
-      } else {
-        // ei organisaatiorajainta, rajataan käyttöoikeuksien organisaatioilla
-        if (selectedHakukohderyhmat.nonEmpty) {
-          val selectedKayttooikeushakukohderyhmat = selectedHakukohderyhmat.intersect(kayttooikeusHakukohderyhmat)
-          val selectedOrganisaationHakukohderyhmat = selectedHakukohderyhmat.diff(kayttooikeusHakukohderyhmat)
+      s"$orgsQuery $selectedHakukohderyhmatQuery".trim
+    } else if (isOrganisaatioRajain && selectedHakukohderyhmat.isEmpty) {
+      orgsQuery
+    } else if (selectedHakukohderyhmat.nonEmpty) {
+      // ei organisaatiorajainta, rajataan käyttöoikeuksien organisaatioilla
+      val selectedKayttooikeushakukohderyhmat = selectedHakukohderyhmat.intersect(kayttooikeusHakukohderyhmat)
+      val selectedOrganisaationHakukohderyhmat = selectedHakukohderyhmat.diff(kayttooikeusHakukohderyhmat)
 
-          val selectedOrganisaationHakukohderyhmatQuery =
-            RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "hkr_hk.hakukohderyhma_oid", selectedOrganisaationHakukohderyhmat)
-          val selectedKayttooikeushakukohderyhmatQuery =
-            RepositoryUtils.makeOptionalListOfValuesQueryStr("OR", "hkr_hk.hakukohderyhma_oid", selectedKayttooikeushakukohderyhmat)
+      val selectedOrganisaationHakukohderyhmatQuery =
+        RepositoryUtils.makeOptionalListOfValuesQueryStr("AND", "hkr_hk.hakukohderyhma_oid", selectedOrganisaationHakukohderyhmat)
+      val selectedKayttooikeushakukohderyhmatQuery =
+        RepositoryUtils.makeOptionalListOfValuesQueryStr("OR", "hkr_hk.hakukohderyhma_oid", selectedKayttooikeushakukohderyhmat)
 
-          val orgQueryStr = orgsQuery.stripPrefix("AND").trim
-          val grouped = List(Some(orgQueryStr), Option(selectedOrganisaationHakukohderyhmatQuery).filter(_.nonEmpty), Option(selectedKayttooikeushakukohderyhmatQuery).filter(_.nonEmpty)).flatten.mkString(" ")
-          s"AND ($grouped)"
-        } else {
-          val kayttooikeusHakukohderymatQuery = RepositoryUtils.makeOptionalListOfValuesQueryStr("OR", "hkr_hk.hakukohderyhma_oid", kayttooikeusHakukohderyhmat)
-          s"${orgsQuery.trim} $kayttooikeusHakukohderymatQuery".trim
-        }
-      }
+      val orgQueryStr = orgsQuery.stripPrefix("AND").trim
+      val grouped = List(Some(orgQueryStr), Option(selectedOrganisaationHakukohderyhmatQuery).filter(_.nonEmpty), Option(selectedKayttooikeushakukohderyhmatQuery).filter(_.nonEmpty)).flatten.mkString(" ")
+      s"AND ($grouped)"
+    } else {
+      val kayttooikeusHakukohderymatQuery = RepositoryUtils.makeOptionalListOfValuesQueryStr("OR", "hkr_hk.hakukohderyhma_oid", kayttooikeusHakukohderyhmat)
+      s"${orgsQuery.trim} $kayttooikeusHakukohderymatQuery".trim
     }
     query
   }

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/RepositoryUtils.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/RepositoryUtils.scala
@@ -155,6 +155,22 @@ object RepositoryUtils {
     }
   }
 
+  def makeHakukohderyhmaQueryWithKayttooikeudet(kayttooikeusOrgOids: List[String],
+                                                kayttooikeusHakukohderyhmaOids: List[String]): String = {
+    val hakukohderyhmaStr = RepositoryUtils.makeListOfValuesQueryStr(kayttooikeusHakukohderyhmaOids)
+    val hakukohderyhmaQueryStr = s"hkr.hakukohderyhma_oid IN ($hakukohderyhmaStr)"
+
+    val hakukohdeOrgStr = RepositoryUtils.makeListOfValuesQueryStr(kayttooikeusOrgOids)
+    val hakukohdeQueryStr = s"hkr_hk.hakukohde_oid IN (SELECT hakukohde_oid FROM pub.pub_dim_hakukohde WHERE jarjestyspaikka_oid IN ($hakukohdeOrgStr))"
+
+    (kayttooikeusHakukohderyhmaOids.isEmpty, kayttooikeusOrgOids.isEmpty) match {
+      case (true, true) => ""
+      case (true, false) => s"AND ($hakukohdeQueryStr)"
+      case (false, true) => s"AND ($hakukohderyhmaQueryStr)"
+      case (false, false) => s"AND ($hakukohderyhmaQueryStr OR $hakukohdeQueryStr)"
+    }
+  }
+
   def enrichHarkinnanvaraisuudet(harkinnanvaraisuudet: List[String]): List[String] = {
     harkinnanvaraisuudet.flatMap(harkinnanvaraisuus => {
       if (List("ATARU_EI_PAATTOTODISTUSTA", "ATARU_YKS_MAT_AI").contains(harkinnanvaraisuus)) {

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/RepositoryUtils.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/RepositoryUtils.scala
@@ -189,7 +189,7 @@ object RepositoryUtils {
     if (orgs.isEmpty && kayttooikeusHakukohderyhmat.isEmpty && !isOphPaakayttaja)
       throw new IllegalArgumentException("Non superuser must have either organization or hakukohderyhma limitation")
     // käyttäjälle sallitut / organisaatiorajatut hakukohteet AND (selected hakukohde OR (selected hakukohderyhmä AND selected haku))
-    val hakukohteetOrganisaatioJaKäyttöoikeusrajauksilla = if (isOrganisaatioRajain) {
+    val hakukohteetOrganisaatioJaKayttooikeusrajauksilla = if (isOrganisaatioRajain) {
       makeHakukohderyhmaQueryWithKayttooikeudet(orgs, List.empty, "hkr_hk")
     } else if (isOphPaakayttaja) {
         ""
@@ -208,7 +208,7 @@ object RepositoryUtils {
     }
     // haku on aina pakollinen rajain, validointi tehdään controllerissa
     val selectedHakuRajaus = s"hk.haku_oid IN (${RepositoryUtils.makeListOfValuesQueryStr(selectedHaut)})"
-    s"$hakukohteetOrganisaatioJaKäyttöoikeusrajauksilla AND ($selectedHakukohdeRajaus ($selectedHakukohderyhmaRajaus $selectedHakuRajaus))"
+    s"$hakukohteetOrganisaatioJaKayttooikeusrajauksilla AND ($selectedHakukohdeRajaus ($selectedHakukohderyhmaRajaus $selectedHakuRajaus))"
   }
 
   def enrichHarkinnanvaraisuudet(harkinnanvaraisuudet: List[String]): List[String] = {
@@ -266,9 +266,9 @@ object RepositoryUtils {
       ""
   }
 
-  def makeOptionalJarjestyspaikkaQuery(selectedKayttooikeusOrganisaatiot: List[String], tablename: String = "hk"): String = {
+  def makeOptionalJarjestyspaikkaQuery(selectedKayttooikeusOrganisaatiot: List[String], tablename: String = "hk", operator: String = "AND"): String = {
     RepositoryUtils.makeOptionalListOfValuesQueryStr(
-      "AND",
+      operator,
       s"$tablename.jarjestyspaikka_oid",
       selectedKayttooikeusOrganisaatiot
     )

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/RepositoryUtils.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/RepositoryUtils.scala
@@ -158,13 +158,14 @@ object RepositoryUtils {
   def makeHakukohderyhmaQueryWithKayttooikeudet(
       kayttooikeusOrgOids: List[String],
       kayttooikeusHakukohderyhmaOids: List[String],
-      hakukohderyhmaTablename: String = "hkr"
+      hakukohderyhmaTablename: String = "hkr",
+      hakukohdeTablename: String = "hk"
   ): String = {
     val hakukohderyhmaStr      = RepositoryUtils.makeListOfValuesQueryStr(kayttooikeusHakukohderyhmaOids)
     val hakukohderyhmaQueryStr = s"$hakukohderyhmaTablename.hakukohderyhma_oid IN ($hakukohderyhmaStr)"
 
     val hakukohdeOrgStr = RepositoryUtils.makeListOfValuesQueryStr(kayttooikeusOrgOids)
-    val hakukohdeQueryStr = s"hk.jarjestyspaikka_oid IN ($hakukohdeOrgStr)"
+    val hakukohdeQueryStr = s"$hakukohdeTablename.jarjestyspaikka_oid IN ($hakukohdeOrgStr)"
 
     (kayttooikeusHakukohderyhmaOids.isEmpty, kayttooikeusOrgOids.isEmpty) match {
       case (true, true)   => ""
@@ -265,21 +266,21 @@ object RepositoryUtils {
       ""
   }
 
-  def makeOptionalJarjestyspaikkaQuery(selectedKayttooikeusOrganisaatiot: List[String]): String = {
+  def makeOptionalJarjestyspaikkaQuery(selectedKayttooikeusOrganisaatiot: List[String], tablename: String = "hk"): String = {
     RepositoryUtils.makeOptionalListOfValuesQueryStr(
       "AND",
-      "hk.jarjestyspaikka_oid",
+      s"$tablename.jarjestyspaikka_oid",
       selectedKayttooikeusOrganisaatiot
     )
   }
 
-  def makeOptionalHakukohderyhmatSubSelectQueryStr(hakukohderyhmat: List[String]): String = {
+  def makeOptionalHakukohderyhmatSubSelectQueryStr(hakukohderyhmat: List[String], hakukohdeTablename: String = "hk", operator: String = "AND"): String = {
     val hakukohderyhmatStr = makeListOfValuesQueryStr(hakukohderyhmat)
     if (hakukohderyhmatStr.isEmpty) {
       ""
     } else {
-      "AND hk.hakukohde_oid IN (" +
-        "SELECT hkr_hk.hakukohde_oid FROM pub.pub_dim_hakukohderyhma_ja_hakukohteet hkr_hk " +
+      s"$operator $hakukohdeTablename.hakukohde_oid IN (" +
+        "SELECT DISTINCT hkr_hk.hakukohde_oid FROM pub.pub_dim_hakukohderyhma_ja_hakukohteet hkr_hk " +
         s"WHERE hkr_hk.hakukohderyhma_oid IN ($hakukohderyhmatStr))"
     }
   }

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/utils/RepositoryUtilsSpec.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/utils/RepositoryUtilsSpec.scala
@@ -325,10 +325,10 @@ class RepositoryUtilsSpec extends AnyFlatSpec {
       kayttooikeusHakukohderyhmat = List.empty,
       isOphPaakayttaja = true
     )
-    result.trim shouldBe "AND hk.jarjestyspaikka_oid IN ('1.2.246.562.10.80593660139')"
+    result.trim shouldBe "AND hk.jarjestyspaikka_oid in ('1.2.246.562.10.80593660139')"
   }
 
-  it should "return jarjestyspaikka for normal user when only orgs filter is provided" in {
+  it should "filter by jarjestyspaikka for normal user when only orgs filter is provided" in {
     val result = RepositoryUtils.buildOrgAndHakukohderyhmaFilter(
       orgs = List("1.2.246.562.10.80593660139"),
       isOrganisaatioRajain = true,
@@ -336,10 +336,10 @@ class RepositoryUtilsSpec extends AnyFlatSpec {
       kayttooikeusHakukohderyhmat = List.empty,
       isOphPaakayttaja = false
     )
-    result shouldBe "AND hk.jarjestyspaikka_oid IN ('1.2.246.562.10.80593660139')"
+    result shouldBe "AND hk.jarjestyspaikka_oid in ('1.2.246.562.10.80593660139')"
   }
 
-  it should "return jarjestyspaikka filter for normal user when no filter is provided" in {
+  it should "filter by jarjestyspaikka for normal user when no filter is provided" in {
     val result = RepositoryUtils.buildOrgAndHakukohderyhmaFilter(
       orgs = List("1.2.246.562.10.80593660139"),
       isOrganisaatioRajain = false,
@@ -347,10 +347,10 @@ class RepositoryUtilsSpec extends AnyFlatSpec {
       kayttooikeusHakukohderyhmat = List.empty,
       isOphPaakayttaja = false
     )
-    result.trim shouldBe "AND hk.jarjestyspaikka_oid IN ('1.2.246.562.10.80593660139')"
+    result.trim shouldBe "AND hk.jarjestyspaikka_oid in ('1.2.246.562.10.80593660139')"
   }
 
-  it should "return a filter for selectedHakukohderyhmat for OphPaakayttaja when only selectedHakukohderyhmat filter is provided" in {
+  it should "only filter by selectedHakukohderyhmat for OphPaakayttaja when no org filter is provided" in {
     val result = RepositoryUtils.buildOrgAndHakukohderyhmaFilter(
       orgs = List.empty,
       isOrganisaatioRajain = false,
@@ -358,7 +358,7 @@ class RepositoryUtilsSpec extends AnyFlatSpec {
       kayttooikeusHakukohderyhmat = List.empty,
       isOphPaakayttaja = true
     )
-    result.trim shouldBe "AND hkr_hk.hakukohderyhma_oid IN ('1.2.246.562.28.95751395146')"
+    result.trim shouldBe "AND hkr_hk.hakukohderyhma_oid in ('1.2.246.562.28.95751395146')"
   }
 
   it should "return a combined filter for orgs and selectedHakukohderyhmat for OphPaakayttaja when both filters are provided" in {
@@ -369,10 +369,10 @@ class RepositoryUtilsSpec extends AnyFlatSpec {
       kayttooikeusHakukohderyhmat = List.empty,
       isOphPaakayttaja = true
     )
-    result shouldBe "AND hk.jarjestyspaikka_oid IN ('1.2.246.562.10.80593660139') AND hkr_hk.hakukohderyhma_oid IN ('1.2.246.562.28.95751395146')"
+    result shouldBe "AND hk.jarjestyspaikka_oid in ('1.2.246.562.10.80593660139') AND hkr_hk.hakukohderyhma_oid in ('1.2.246.562.28.95751395146')"
   }
 
-  it should "return a combined filter to both organisaatios and selected hakukohderyhmas when both filters are provided" in {
+  it should "filter by both orgs and selected hakukohderyhmas when both filters are provided" in {
     val result = RepositoryUtils.buildOrgAndHakukohderyhmaFilter(
       orgs = List("1.2.246.562.10.80593660139"),
       isOrganisaatioRajain = true,
@@ -380,10 +380,10 @@ class RepositoryUtilsSpec extends AnyFlatSpec {
       kayttooikeusHakukohderyhmat = List("1.2.246.562.28.95751395146"),
       isOphPaakayttaja = false
     )
-    result shouldBe "AND hk.jarjestyspaikka_oid IN ('1.2.246.562.10.80593660139') AND hkr_hk.hakukohderyhma_oid IN ('1.2.246.562.28.95751395146', '1.2.246.562.28.81326045473')"
+    result shouldBe "AND hk.jarjestyspaikka_oid in ('1.2.246.562.10.80593660139') AND hkr_hk.hakukohderyhma_oid in ('1.2.246.562.28.95751395146', '1.2.246.562.28.81326045473')"
   }
 
-  it should "return a filter including hakukohderyhmat outside of organisation if there is no org filter and hakukohderyhmafilter is provided" in {
+  it should "include kayttooikeusHakukohderyhmat outside of user's organisations if there is no org filter and hakukohderyhmafilter is provided" in {
     val result = RepositoryUtils.buildOrgAndHakukohderyhmaFilter(
       orgs = List("1.2.246.562.10.80593660139"),
       isOrganisaatioRajain = false,
@@ -391,10 +391,10 @@ class RepositoryUtilsSpec extends AnyFlatSpec {
       kayttooikeusHakukohderyhmat = List("1.2.246.562.28.95751395146"),
       isOphPaakayttaja = false
     )
-    result shouldBe "AND (hk.jarjestyspaikka_oid IN ('1.2.246.562.10.80593660139') AND hkr_hk.hakukohderyhma_oid IN ('1.2.246.562.28.95751395146', '1.2.246.562.28.81326045473') OR hkr_hk.hakukohderyhma_oid IN ('1.2.246.562.28.95751395146'))"
+    result shouldBe "AND (hk.jarjestyspaikka_oid in ('1.2.246.562.10.80593660139') AND hkr_hk.hakukohderyhma_oid in ('1.2.246.562.28.81326045473') OR hkr_hk.hakukohderyhma_oid in ('1.2.246.562.28.95751395146'))"
   }
 
-  it should "return a filter for jarjestyspaikka and kayttooikeusHakukohderyhmat when no org or hakukohderyhma filters are provided" in {
+  it should "filter by jarjestyspaikka and kayttooikeusHakukohderyhmat when no org or hakukohderyhma filters are provided" in {
     val result = RepositoryUtils.buildOrgAndHakukohderyhmaFilter(
       orgs = List("1.2.246.562.10.80593660139"),
       isOrganisaatioRajain = false,
@@ -402,7 +402,18 @@ class RepositoryUtilsSpec extends AnyFlatSpec {
       kayttooikeusHakukohderyhmat = List("1.2.246.562.28.95751395146"),
       isOphPaakayttaja = false
     )
-    result shouldBe "AND hk.jarjestyspaikka_oid IN ('1.2.246.562.10.80593660139') OR hkr_hk.hakukohderyhma_oid IN ('1.2.246.562.28.95751395146')"
+    result shouldBe "AND hk.jarjestyspaikka_oid in ('1.2.246.562.10.80593660139') OR hkr_hk.hakukohderyhma_oid in ('1.2.246.562.28.95751395146')"
+  }
+
+  it should "filter by kayttooikeusHakukohderyhmat if user has no organisations" in {
+    val result = RepositoryUtils.buildOrgAndHakukohderyhmaFilter(
+      orgs = List.empty,
+      isOrganisaatioRajain = false,
+      selectedHakukohderyhmat = List.empty,
+      kayttooikeusHakukohderyhmat = List("1.2.246.562.28.95751395146"),
+      isOphPaakayttaja = false
+    )
+    result shouldBe "AND hkr_hk.hakukohderyhma_oid in ('1.2.246.562.28.95751395146')"
   }
 
   "enrichHarkinnanvaraisuudet" should "add SURE_EI_PAATTOTODISTUSTA to harkinnanvaraisuudet when ATARU_EI_PAATTOTODISTUSTA is selected" in {

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/utils/RepositoryUtilsSpec.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/utils/RepositoryUtilsSpec.scala
@@ -286,6 +286,26 @@ class RepositoryUtilsSpec extends AnyFlatSpec {
     )
   }
 
+  "makeHakukohderyhmaQueryWithKayttooikeudet" should "return an empty string when both lists are empty" in {
+    val result = RepositoryUtils.makeHakukohderyhmaQueryWithKayttooikeudet(List.empty, List.empty)
+    result shouldBe ""
+  }
+
+  it should "return the hakukohde query string when only kayttooikeusOrgOids contains values" in {
+    val result = RepositoryUtils.makeHakukohderyhmaQueryWithKayttooikeudet(List("1.2.3"), List.empty)
+    result shouldBe "AND (hkr_hk.hakukohde_oid IN (SELECT hakukohde_oid FROM pub.pub_dim_hakukohde WHERE jarjestyspaikka_oid IN ('1.2.3')))"
+  }
+
+  it should "return the hakukohderyhma query string when only kayttooikeusHakukohderyhmaOids contains values" in {
+    val result = RepositoryUtils.makeHakukohderyhmaQueryWithKayttooikeudet(List.empty, List("4.5.6"))
+    result shouldBe "AND (hkr.hakukohderyhma_oid IN ('4.5.6'))"
+  }
+
+  it should "return both query strings combined with OR when both lists contain values" in {
+    val result = RepositoryUtils.makeHakukohderyhmaQueryWithKayttooikeudet(List("1.2.3"), List("4.5.6"))
+    result shouldBe "AND (hkr.hakukohderyhma_oid IN ('4.5.6') OR hkr_hk.hakukohde_oid IN (SELECT hakukohde_oid FROM pub.pub_dim_hakukohde WHERE jarjestyspaikka_oid IN ('1.2.3')))"
+  }
+
   "enrichHarkinnanvaraisuudet" should "add SURE_EI_PAATTOTODISTUSTA to harkinnanvaraisuudet when ATARU_EI_PAATTOTODISTUSTA is selected" in {
     assert(
       RepositoryUtils.enrichHarkinnanvaraisuudet(List("ATARU_OPPIMISVAIKEUDET", "ATARU_EI_PAATTOTODISTUSTA")) == List(

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/utils/RepositoryUtilsSpec.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/utils/RepositoryUtilsSpec.scala
@@ -306,6 +306,27 @@ class RepositoryUtilsSpec extends AnyFlatSpec {
     result shouldBe "AND (hkr.hakukohderyhma_oid IN ('4.5.6') OR hk.jarjestyspaikka_oid IN ('1.2.3'))"
   }
 
+  "makeHakukohderyhmaSubSelectQueryWithKayttooikeudet" should "return an empty string when both lists are empty" in {
+    val result = RepositoryUtils.makeHakukohderyhmaSubSelectQueryWithKayttooikeudet(List.empty, List.empty)
+    result shouldBe ""
+  }
+
+  it should "return the hakukohde query string when only kayttooikeusOrgOids contains values" in {
+    val result = RepositoryUtils.makeHakukohderyhmaSubSelectQueryWithKayttooikeudet(List("1.2.3"), List.empty)
+    result shouldBe "AND hk.jarjestyspaikka_oid in ('1.2.3')"
+  }
+
+  it should "return the hakukohderyhma subselect query string when only kayttooikeusHakukohderyhmaOids contains values" in {
+    val result = RepositoryUtils.makeHakukohderyhmaSubSelectQueryWithKayttooikeudet(List.empty, List("4.5.6"))
+    result shouldBe "AND hk.hakukohde_oid IN (SELECT DISTINCT hkr_hk.hakukohde_oid FROM pub.pub_dim_hakukohderyhma_ja_hakukohteet hkr_hk WHERE hkr_hk.hakukohderyhma_oid IN ('4.5.6'))"
+  }
+
+  it should "return both query strings combined with OR when both lists contain values" in {
+    val result = RepositoryUtils.makeHakukohderyhmaSubSelectQueryWithKayttooikeudet(List("1.2.3"), List("4.5.6"))
+    result shouldBe "AND (hk.hakukohde_oid IN (SELECT DISTINCT hkr_hk.hakukohde_oid FROM pub.pub_dim_hakukohderyhma_ja_hakukohteet hkr_hk WHERE hkr_hk.hakukohderyhma_oid IN ('4.5.6')) OR hk.jarjestyspaikka_oid in ('1.2.3'))"
+  }
+
+
   "buildHakukohdeFilterQuery" should "not limit organisation or hakukohderyhma for OphPaakayttaja when there are no selected filters except haku" in {
     val result = RepositoryUtils.buildHakukohdeFilterQuery(
       selectedHakukohteet = List.empty,

--- a/ovara-ui/src/app/hooks/useFetchHakukohteet.tsx
+++ b/ovara-ui/src/app/hooks/useFetchHakukohteet.tsx
@@ -95,5 +95,7 @@ export const useFetchHakukohteet = (
         selectedHakukohteet,
       ),
     enabled: fetchEnabled,
+    staleTime: 5 * 60 * 1000, // Data is fresh for 5 minutes
+    gcTime: 30 * 60 * 1000, // Data stays in memory for 30 minutes
   });
 };


### PR DESCRIPTION
Rajataan hakukohderyhmä-valikko haun lisäksi käyttöoikeuden perusteella, eli näytetään ne hakukohderyhmät joihin käyttäjällä on oikeus joko organisaation tai hakukohderyhmän kautta.
- hakukohderyhmät joihin kuuluu käyttäjän organisaation hakukohteita (mutta voi kuulua muitakin)
- hakukohderyhmät joihin on annettu suoraan käyttöoikeus

Jos on valittu hakukohderyhmä, näytetään vain ne hakukohderyhmän hakukohteet, joihin virkailijalla on oikeus eli
- valittuun hakukohderyhmään kuuluvat oman organisaation hakukohteet tai
- käyttöoikeuksiin kuuluvan hakukohderyhmän hakukohteet, jolloin voi olla mukana muiden organisaatioiden hakukohteita