### PR TITLE
OY-5518 Hakeneet, hyväksyneet ja paikan vastaanottaneet -raportin Hakurajaimien korjaus

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ brew install mkcert
 
 Generoi varmenne ajamalla projektin juuressa:
 ```
-./generate-certs.sh
+./generate_certs.sh
 ```
 
 Backendiä ajetaan IDEA:ssa (`/src/main/scala/fi/oph/ovara/backend/OvaraBackendApplication.scala`). Kehitysympäristön konfiguraatio määritellään `/src/main/resources/application-dev.properties`-nimisessä tiedostossa

--- a/ovara-backend/pom.xml
+++ b/ovara-backend/pom.xml
@@ -280,6 +280,11 @@
             <artifactId>logback-access-tomcat</artifactId>
             <version>2.0.6</version>
         </dependency>
+        <dependency>
+            <groupId>org.asynchttpclient</groupId>
+            <artifactId>async-http-client</artifactId>
+            <version>3.0.1</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/CommonRepository.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/CommonRepository.scala
@@ -116,10 +116,24 @@ class CommonRepository extends Extractors {
        """.as[Koodi]
   }
 
+  def selectOpetuskieliKoodiurit(koodiarvot: List[String]): SqlStreamingAction[Vector[String], String, Effect] = {
+    sql"""SELECT ook.koodiuri
+          FROM pub.pub_dim_koodisto_oppilaitoksenopetuskieli ook
+          WHERE ook.koodiarvo in (#${RepositoryUtils.makeListOfValuesQueryStr(koodiarvot)})
+       """.as[String]
+  }
+
   def selectDistinctMaakunnat: SqlStreamingAction[Vector[Koodi], Koodi, Effect] = {
     sql"""SELECT mk.koodiarvo, mk.koodinimi
           FROM pub.pub_dim_koodisto_maakunta mk
        """.as[Koodi]
+  }
+
+  def selectMaakuntaKoodiurit(koodiarvot: List[String]): SqlStreamingAction[Vector[String], String, Effect] = {
+    sql"""SELECT mk.koodiuri
+          FROM pub.pub_dim_koodisto_maakunta mk
+          WHERE mk.koodiarvo in (#${RepositoryUtils.makeListOfValuesQueryStr(koodiarvot)})
+       """.as[String]
   }
 
   def selectDistinctKunnat(
@@ -137,6 +151,13 @@ class CommonRepository extends Extractors {
           JOIN pub.pub_dim_koodisto_kunta_maakunta km
           ON k.koodiarvo = km.kunta_koodiarvo
           #$whereClause""".as[Koodi]
+  }
+
+  def selectKuntaKoodiurit(koodiarvot: List[String]): SqlStreamingAction[Vector[String], String, Effect] = {
+    sql"""SELECT k.koodiuri
+          FROM pub.pub_dim_koodisto_kunta k
+          WHERE k.koodiarvo in (#${RepositoryUtils.makeListOfValuesQueryStr(koodiarvot)})
+       """.as[String]
   }
 
   def selectHakukohderyhmat(

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/CommonService.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/CommonService.scala
@@ -1,6 +1,6 @@
 package fi.oph.ovara.backend.service
 
-import fi.oph.ovara.backend.domain.*
+import fi.oph.ovara.backend.domain.{Haku, Hakukohde, Hakukohderyhma, Koodi, Organisaatio, OrganisaatioHierarkia}
 import fi.oph.ovara.backend.repository.{CommonRepository, ReadOnlyDatabase}
 import fi.oph.ovara.backend.utils.Constants.{
   KOULUTUSTOIMIJARAPORTTI,
@@ -16,6 +16,7 @@ import org.springframework.cache.annotation.{CacheEvict, Cacheable}
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.{Component, Service}
 
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 @Component
@@ -159,6 +160,17 @@ class CommonService(commonRepository: CommonRepository, userService: UserService
     }
   }
 
+  def getOpetuskieliKoodiurit(koodiarvot: List[String]): Try[Vector[String]] =
+    Try {
+      if (koodiarvot.nonEmpty) {
+        db.run(commonRepository.selectOpetuskieliKoodiurit(koodiarvot), "selectOpetuskieliKoodiurit")
+      } else Vector.empty
+    }.recoverWith {
+      case NonFatal(exception) =>
+        LOG.error("Error fetching opetuskielet", exception)
+        Failure(exception)
+    }
+
   def getMaakunnat: Either[String, Vector[Koodi]] = {
     Try {
       db.run(commonRepository.selectDistinctMaakunnat, "selectDistinctMaakunnat")
@@ -170,6 +182,17 @@ class CommonService(commonRepository: CommonRepository, userService: UserService
     }
   }
 
+  def getMaakuntaKoodiUrit(koodiarvot: List[String]): Try[Vector[String]] =
+    Try {
+      if (koodiarvot.nonEmpty) {
+        db.run(commonRepository.selectMaakuntaKoodiurit(koodiarvot), "selectMaakuntaKoodiurit")
+      } else Vector.empty
+    }.recoverWith {
+      case NonFatal(exception) =>
+        LOG.error("Error fetching maakunnat", exception)
+        Failure(exception)
+    }
+
   def getKunnat(maakunnat: List[String], selectedKunnat: List[String]): Either[String, Vector[Koodi]] = {
     Try {
       db.run(commonRepository.selectDistinctKunnat(maakunnat, selectedKunnat), "selectDistinctKunnat")
@@ -178,6 +201,18 @@ class CommonService(commonRepository: CommonRepository, userService: UserService
       case Failure(exception) =>
         LOG.error("Error fetching kunnat", exception)
         Left("virhe.tietokanta")
+    }
+  }
+
+  def getKuntaKoodiurit(koodiarvot: List[String]): Try[Vector[String]] = {
+    Try {
+      if (koodiarvot.nonEmpty) {
+        db.run(commonRepository.selectKuntaKoodiurit(koodiarvot), "selectKuntaKoodiurit")
+      } else Vector.empty
+    }.recoverWith {
+      case NonFatal(exception) =>
+        LOG.error("Error fetching kunnat", exception)
+        Failure(exception)
     }
   }
 

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/HakeneetHyvaksytytVastaanottaneetService.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/service/HakeneetHyvaksytytVastaanottaneetService.scala
@@ -56,7 +56,12 @@ class HakeneetHyvaksytytVastaanottaneetService(
       oppilaitosOids = oppilaitokset,
       koulutustoimijaOid = koulutustoimija
     )
+
     Try {
+      val maakuntaKoodiurit = commonService.getMaakuntaKoodiUrit(maakunnat).get.toList
+      val kuntaKoodiurit = commonService.getKuntaKoodiurit(kunnat).get.toList
+      val opetuskieliKoodiurit = commonService.getOpetuskieliKoodiurit(opetuskielet).get.toList
+
       val queryResult = tulostustapa match {
         case "hakukohteittain" =>
             val query = hakeneetHyvaksytytVastaanottaneetRepository.selectHakukohteittainWithParams(
@@ -66,9 +71,9 @@ class HakeneetHyvaksytytVastaanottaneetService(
               koulutusalat1 = koulutusalat1,
               koulutusalat2 = koulutusalat2,
               koulutusalat3 = koulutusalat3,
-              opetuskielet = opetuskielet,
-              maakunnat = maakunnat,
-              kunnat = kunnat,
+              opetuskielet = opetuskieliKoodiurit,
+              maakunnat = maakuntaKoodiurit,
+              kunnat = kuntaKoodiurit,
               harkinnanvaraisuudet = harkinnanvaraisuudet,
               sukupuoli = sukupuoli
             )
@@ -81,9 +86,9 @@ class HakeneetHyvaksytytVastaanottaneetService(
               koulutusalat1 = koulutusalat1,
               koulutusalat2 = koulutusalat2,
               koulutusalat3 = koulutusalat3,
-              opetuskielet = opetuskielet,
-              maakunnat = maakunnat,
-              kunnat = kunnat,
+              opetuskielet = opetuskieliKoodiurit,
+              maakunnat = maakuntaKoodiurit,
+              kunnat = kuntaKoodiurit,
               harkinnanvaraisuudet = harkinnanvaraisuudet,
               sukupuoli = sukupuoli
             )
@@ -97,9 +102,9 @@ class HakeneetHyvaksytytVastaanottaneetService(
               koulutusalat1 = koulutusalat1,
               koulutusalat2 = koulutusalat2,
               koulutusalat3 = koulutusalat3,
-              opetuskielet = opetuskielet,
-              maakunnat = maakunnat,
-              kunnat = kunnat,
+              opetuskielet = opetuskieliKoodiurit,
+              maakunnat = maakuntaKoodiurit,
+              kunnat = kuntaKoodiurit,
               harkinnanvaraisuudet = harkinnanvaraisuudet,
               sukupuoli = sukupuoli
             )
@@ -113,9 +118,9 @@ class HakeneetHyvaksytytVastaanottaneetService(
               koulutusalat1 = koulutusalat1,
               koulutusalat2 = koulutusalat2,
               koulutusalat3 = koulutusalat3,
-              opetuskielet = opetuskielet,
-              maakunnat = maakunnat,
-              kunnat = kunnat,
+              opetuskielet = opetuskieliKoodiurit,
+              maakunnat = maakuntaKoodiurit,
+              kunnat = kuntaKoodiurit,
               harkinnanvaraisuudet = harkinnanvaraisuudet,
               sukupuoli = sukupuoli,
               organisaatiotaso = tulostustapa

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/ParameterValidator.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/ParameterValidator.scala
@@ -257,9 +257,9 @@ object ParameterValidator {
       validateNumericList(params.koulutusalat1, "koulutusalat1"),
       validateNumericList(params.koulutusalat2, "koulutusalat2"),
       validateNumericList(params.koulutusalat3, "koulutusalat3"),
-      validateAlphanumericList(params.opetuskielet, "opetuskielet"),
-      validateAlphanumericList(params.maakunnat, "maakunnat"),
-      validateAlphanumericList(params.kunnat, "kunnat"),
+      validateNumericList(params.opetuskielet, "opetuskielet"),
+      validateNumericList(params.maakunnat, "maakunnat"),
+      validateNumericList(params.kunnat, "kunnat"),
       validateAlphanumericList(params.harkinnanvaraisuudet, "harkinnanvaraisuudet"),
       validateNumeric(params.sukupuoli, "sukupuoli"),
       validateBoolean(params.naytaHakutoiveet, "nayta-hakutoiveet")

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/utils/ParameterValidatorSpec.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/utils/ParameterValidatorSpec.scala
@@ -141,9 +141,9 @@ class ParameterValidatorSpec extends AnyFlatSpec with Matchers {
       koulutusalat1 = List("foo"),
       koulutusalat2 = List("bar"),
       koulutusalat3 = List("baz"),
-      opetuskielet = List("invalid*-kieli"),
-      maakunnat = List("invalid*-maakunta"),
-      kunnat = List("invalid*-kunta"),
+      opetuskielet = List("oppilaitoksenopetuskieli_1"),
+      maakunnat = List("maakunta_01"),
+      kunnat = List("kunta_001"),
       harkinnanvaraisuudet = List("FOOBAR''"),
       sukupuoli = Some("invalid-sukupuoli"),
       naytaHakutoiveet = "invalid-boolean"
@@ -168,6 +168,48 @@ class ParameterValidatorSpec extends AnyFlatSpec with Matchers {
       "sukupuoli.invalid",
       "nayta-hakutoiveet.invalid"
     ))
+  }
+
+  it should "return no errors for valid parameters" in {
+
+    val params = RawHakeneetHyvaksytytVastaanottaneetParams(
+      haut = List("1.2.246.562.29.00000000000000056840"),
+      tulostustapa = "hakukohteittain",
+      koulutustoimija = Some("1.2.246.562.10.346830761110"),
+      oppilaitokset = List("1.2.246.562.10.52251087186"),
+      toimipisteet = List("1.2.246.562.10.55711304158"),
+      hakukohteet = List("1.2.246.562.20.00000000000000059958"),
+      koulutusalat1 = List("09"),
+      koulutusalat2 = List("092"),
+      koulutusalat3 = List("0922"),
+      opetuskielet = List("1"),
+      maakunnat = List("21"),
+      kunnat = List("004"),
+      harkinnanvaraisuudet = List("ATARU_EI_PAATTOTODISTUSTA"),
+      sukupuoli = Some("2"),
+      naytaHakutoiveet = "true"
+    )
+
+    val expected = ValidatedHakeneetHyvaksytytVastaanottaneetParams(
+      haut = List("1.2.246.562.29.00000000000000056840"),
+      tulostustapa = "hakukohteittain",
+      koulutustoimija = Some("1.2.246.562.10.346830761110"),
+      oppilaitokset = List("1.2.246.562.10.52251087186"),
+      toimipisteet = List("1.2.246.562.10.55711304158"),
+      hakukohteet = List("1.2.246.562.20.00000000000000059958"),
+      koulutusalat1 = List("09"),
+      koulutusalat2 = List("092"),
+      koulutusalat3 = List("0922"),
+      opetuskielet = List("1"),
+      maakunnat = List("21"),
+      kunnat = List("004"),
+      harkinnanvaraisuudet = List("ATARU_EI_PAATTOTODISTUSTA"),
+      sukupuoli = Some("2"),
+      naytaHakutoiveet = true,
+    )
+    val result = ParameterValidator.validateHakeneetHyvaksytytVastaanottaneetParams(params)
+
+    result shouldBe Right(expected)
   }
 
   "validateKkHakeneetHyvaksytytVastaanottaneetParams" should "return errors for invalid parameters" in {
@@ -210,42 +252,40 @@ class ParameterValidatorSpec extends AnyFlatSpec with Matchers {
 
   it should "return no errors for valid parameters" in {
 
-    val params = RawHakeneetHyvaksytytVastaanottaneetParams(
+    val params = RawKkHakeneetHyvaksytytVastaanottaneetParams(
       haut = List("1.2.246.562.29.00000000000000056840"),
       tulostustapa = "hakukohteittain",
       koulutustoimija = Some("1.2.246.562.10.346830761110"),
       oppilaitokset = List("1.2.246.562.10.52251087186"),
       toimipisteet = List("1.2.246.562.10.55711304158"),
       hakukohteet = List("1.2.246.562.20.00000000000000059958"),
-      koulutusalat1 = List("09"),
-      koulutusalat2 = List("092"),
-      koulutusalat3 = List("0922"),
-      opetuskielet = List("oppilaitoksenopetuskieli_1"),
-      maakunnat = List("maakunta_21"),
-      kunnat = List("kunta_004"),
-      harkinnanvaraisuudet = List("ATARU_EI_PAATTOTODISTUSTA"),
+      hakukohderyhmat = List("1.2.246.562.20.00000000000000059958"),
+      okmOhjauksenAlat = List("11"),
+      tutkinnonTasot = List("alempi"),
+      aidinkielet = List("baz"),
+      kansalaisuusluokat = List("013"),
       sukupuoli = Some("2"),
+      ensikertalainen = "true",
       naytaHakutoiveet = "true"
     )
 
-    val expected = ValidatedHakeneetHyvaksytytVastaanottaneetParams(
+    val expected = ValidatedKkHakeneetHyvaksytytVastaanottaneetParams(
       haut = List("1.2.246.562.29.00000000000000056840"),
       tulostustapa = "hakukohteittain",
       koulutustoimija = Some("1.2.246.562.10.346830761110"),
       oppilaitokset = List("1.2.246.562.10.52251087186"),
       toimipisteet = List("1.2.246.562.10.55711304158"),
       hakukohteet = List("1.2.246.562.20.00000000000000059958"),
-      koulutusalat1 = List("09"),
-      koulutusalat2 = List("092"),
-      koulutusalat3 = List("0922"),
-      opetuskielet = List("oppilaitoksenopetuskieli_1"),
-      maakunnat = List("maakunta_21"),
-      kunnat = List("kunta_004"),
-      harkinnanvaraisuudet = List("ATARU_EI_PAATTOTODISTUSTA"),
+      hakukohderyhmat = List("1.2.246.562.20.00000000000000059958"),
+      okmOhjauksenAlat = List("11"),
+      tutkinnonTasot = List("alempi"),
+      aidinkielet = List("baz"),
+      kansalaisuusluokat = List("013"),
       sukupuoli = Some("2"),
+      ensikertalainen = Some(true),
       naytaHakutoiveet = true,
     )
-    val result = ParameterValidator.validateHakeneetHyvaksytytVastaanottaneetParams(params)
+    val result = ParameterValidator.validateKkHakeneetHyvaksytytVastaanottaneetParams(params)
 
     result shouldBe Right(expected)
   }

--- a/ovara-ui/src/app/components/form/koulutusalavalikot.tsx
+++ b/ovara-ui/src/app/components/form/koulutusalavalikot.tsx
@@ -39,7 +39,7 @@ export const KoulutusalaValikot = () => {
     queryFn: () =>
       doApiFetch('koulutusalat2', {
         queryParams: selectedKoulutusalat1
-          ? `?koulutusalat1=${selectedKoulutusalat1}&selectedKoulutusalat2=${selectedKoulutusalat2 ? selectedKoulutusalat2 : []}`
+          ? `?ovara_koulutusalat1=${selectedKoulutusalat1}&ovara_selectedKoulutusalat2=${selectedKoulutusalat2 ? selectedKoulutusalat2 : []}`
           : null,
       }),
   });
@@ -53,7 +53,7 @@ export const KoulutusalaValikot = () => {
     queryFn: () =>
       doApiFetch('koulutusalat3', {
         queryParams: selectedKoulutusalat2
-          ? `?koulutusalat2=${selectedKoulutusalat2}&selectedKoulutusalat3=${selectedKoulutusalat3 ? selectedKoulutusalat3 : []}`
+          ? `?ovara_koulutusalat2=${selectedKoulutusalat2}&ovara_selectedKoulutusalat3=${selectedKoulutusalat3 ? selectedKoulutusalat3 : []}`
           : null,
       }),
   });

--- a/ovara-ui/src/app/components/form/maakunta-kunta.tsx
+++ b/ovara-ui/src/app/components/form/maakunta-kunta.tsx
@@ -33,7 +33,7 @@ export const MaakuntaKuntaValikot = () => {
     queryFn: () =>
       doApiFetch('kunnat', {
         queryParams: selectedMaakunnat
-          ? `?maakunnat=${selectedMaakunnat}&selectedKunnat=${selectedKunnat ? selectedKunnat : []}`
+          ? `?ovara_maakunnat=${selectedMaakunnat}&ovara_selectedKunnat=${selectedKunnat ? selectedKunnat : []}`
           : null,
       }),
   });


### PR DESCRIPTION
Muunnetaan hakurajaimiin asetetut maakuntien, kuntien ja opetuskielien koodiarvot koodiureiksi ennen kuin ne annetaan raportin muodostavalle metodille. Ne ovat hakukohteiden kannassa koodiureina, joten muunnoksen jälkeen hakurajaimet toimivat taas oikein. Vaihdetaan maakuntien, kuntien ja opetuskielien validointi validoimaan ne numeerisiksi listoiksi, korostamaan sitä, että ne annetaan koodiarvoina.

Korjataan myös koulutuksen sijaintikunta -valikon filtteröinti valitun maakunnan mukaan.