### PR TITLE
OY-5554 Rajapinta opiskelijavalintatietojen hakemiseen 

### DIFF
--- a/.github/actions/setup-next-env/action.yml
+++ b/.github/actions/setup-next-env/action.yml
@@ -3,20 +3,20 @@ description: 'Setup Next.js environment'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version-file: 'ovara-ui/.nvmrc'
         cache: 'npm'
         cache-dependency-path: ovara-ui/package-lock.json
         registry-url: 'https://npm.pkg.github.com'
         scope: '@opetushallitus'
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: node_modules-cache
       with:
         path: ${{ github.workspace }}/ovara-ui/node_modules
         key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}
     - name: Cache Next.js
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/ovara-ui/.next/cache
         key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('next.config.*', './src/**/*.ts', './src/**/*.tsx') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: restore-build
         with:
           path: |
@@ -24,7 +24,7 @@ jobs:
           key: ${{ github.sha }}
 
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -32,15 +32,16 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'corretto'
           cache: 'maven'
 
-      - uses: szenius/set-timezone@v1.0
-        with:
-          timezoneLinux: "Europe/Helsinki"
+      - name: Set timezone to Europe/Helsinki
+        run: |
+          sudo timedatectl set-timezone Europe/Helsinki
+          echo "Europe/Helsinki" | sudo tee /etc/timezone
 
       - name: Build with Maven
         env:
@@ -55,9 +56,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: restore-build
         with:
           path: |
@@ -87,8 +88,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://npm.pkg.github.com'
@@ -107,8 +108,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://npm.pkg.github.com'
@@ -131,8 +132,8 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://npm.pkg.github.com'
@@ -142,7 +143,7 @@ jobs:
           cd ovara-ui
           npm ci --no-audit --prefer-offline
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_OPH_UTILITY_ROLE_ARN }}
           role-session-name: ovara-ui-deploy-zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-next-env
       - name: Install CDK dependencies
         run: |

--- a/ovara-backend/pom.xml
+++ b/ovara-backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.6</version>
+        <version>3.5.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>fi.oph.ovara</groupId>
@@ -33,8 +33,8 @@
         <postgresql.version>42.7.7</postgresql.version>
         <flyway.version>11.11.1</flyway.version>
         <slick.version>3.6.1</slick.version>
-        <spring-context.version>6.2.11</spring-context.version>
-        <spring-security-cas.version>6.5.5</spring-security-cas.version>
+        <spring-context.version>6.2.17</spring-context.version>
+        <spring-security-cas.version>6.5.9</spring-security-cas.version>
         <jackson.version>2.19.2</jackson.version>
         <json4s.version>4.1.0-M8</json4s.version>
         <apache.poi.version>5.4.0</apache.poi.version>
@@ -88,10 +88,6 @@
                 <artifactId>commons-io</artifactId>
                 <version>2.16.1</version>
             </dependency>
-            <dependency>
-                <groupId>netty-codec-http2</groupId>
-                <artifactId>4.2.4.Final</artifactId>
-            </dependency>
             <!-- Enforce a specific version for error_prone_annotations -->
             <dependency>
                 <groupId>com.google.errorprone</groupId>
@@ -103,6 +99,13 @@
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-runtime</artifactId>
                 <version>4.13.2</version>
+            </dependency>
+
+            <dependency>
+                <!-- Tietoturvahaavoittuvuus versiossa 10.1.53, joka tulee Spring Boot 3.5.13 mukana. -->
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.54</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -133,18 +136,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-codec-http2</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- lisätään erillisenä riippuvuutena jotta saa tietoturvallisen version -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>4.2.4.Final</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/Dto.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/Dto.scala
@@ -1,0 +1,180 @@
+package fi.oph.ovara.backend.opiskelijavalintatieto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
+import fi.oph.ovara.backend.domain.{En, Fi, Kielistetty, Sv}
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode
+
+import java.util.Optional
+import scala.annotation.meta.field
+import scala.beans.BeanProperty
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.RichOption
+
+case class OpiskelijavalintatietoResponse(
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty oppijanumero: String,
+    @(Schema @field)(requiredMode = RequiredMode.NOT_REQUIRED)
+    @BeanProperty hetu: String,
+    @(Schema @field)(requiredMode = RequiredMode.NOT_REQUIRED)
+    @BeanProperty syntymaaika: String,
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty sukunimi: String,
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty etunimet: String,
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty hakemukset: java.util.List[HakemusResponse]
+)
+
+object OpiskelijavalintatietoResponse {
+  def apply(opiskelijavalintatieto: Opiskelijavalintatieto): OpiskelijavalintatietoResponse =
+    OpiskelijavalintatietoResponse(
+      oppijanumero = opiskelijavalintatieto.oppijanumero,
+      hetu = opiskelijavalintatieto.hetu,
+      syntymaaika = opiskelijavalintatieto.syntymaaika,
+      sukunimi = opiskelijavalintatieto.sukunimi,
+      etunimet = opiskelijavalintatieto.etunimet,
+      hakemukset = opiskelijavalintatieto.hakemukset.map(HakemusResponse.apply).asJava
+    )
+}
+
+case class HakemusResponse(
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty hakemusOid: String,
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty haku: NimettyResponse,
+    @(Schema @field)(
+      requiredMode = RequiredMode.REQUIRED,
+      description =
+        "Viittaa koodistoon [haun kohdejoukko](https://virkailija.opintopolku.fi/koodisto-service/ui/koodisto/view/haunkohdejoukko)"
+    )
+    @BeanProperty haunKohdejoukko: Optional[String],
+    @(Schema @field)(
+      requiredMode = RequiredMode.REQUIRED,
+      description =
+        "Viittaa koodistoon [hakutapa](https://virkailija.opintopolku.fi/koodisto-service/ui/koodisto/view/hakutapa)"
+    )
+    @BeanProperty hakutapa: Optional[String],
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty hakutoiveet: java.util.List[HakutoiveResponse]
+)
+
+object HakemusResponse {
+  def apply(hakemus: Hakemus): HakemusResponse =
+    HakemusResponse(
+      hakemusOid = hakemus.hakemusOid,
+      haku = NimettyResponse(hakemus.haku),
+      haunKohdejoukko = hakemus.haunKohdejoukko.toJava,
+      hakutapa = hakemus.hakutapa.toJava,
+      hakutoiveet = hakemus.hakutoiveet.map(HakutoiveResponse.apply).asJava
+    )
+}
+
+case class HakutoiveResponse(
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty hakukohde: NimettyResponse,
+    @(Schema @field)(requiredMode = RequiredMode.NOT_REQUIRED)
+    @BeanProperty tarjoaja: Optional[NimettyResponse],
+    @(Schema @field)(
+      requiredMode = RequiredMode.NOT_REQUIRED,
+      description =
+        "Viittaa koodistoon [kausi](https://virkailija.opintopolku.fi/koodisto-service/ui/koodisto/view/kausi)"
+    )
+    @BeanProperty koulutuksenAlkamiskausiUri: Optional[String],
+    @(Schema @field)(requiredMode = RequiredMode.NOT_REQUIRED)
+    @BeanProperty koulutuksenAlkamisvuosi: Optional[Integer],
+    @(Schema @field)(
+      requiredMode = RequiredMode.NOT_REQUIRED,
+      allowableValues = Array(
+        "HYVAKSYTTY",
+        "VARASIJALTA_HYVAKSYTTY",
+        "HARKINNANVARAISESTI_HYVAKSYTTY",
+        "VARALLA",
+        "HYLATTY",
+        "PERUUNTUNUT",
+        "PERUNUT",
+        "PERUUTETTU",
+        "KESKEN"
+      )
+    )
+    @BeanProperty valinnanTila: Optional[String],
+    @(Schema @field)(
+      requiredMode = RequiredMode.NOT_REQUIRED,
+      allowableValues = Array(
+        "EHDOLLISESTI_VASTAANOTTANUT",
+        "VASTAANOTTANUT_SITOVASTI",
+        "EI_VASTAANOTETTU_MAARA_AIKANA",
+        "PERUNUT",
+        "PERUUTETTU",
+        "OTTANUT_VASTAAN_TOISEN_PAIKAN",
+        "KESKEN"
+      )
+    )
+    @BeanProperty vastaanotonTila: Optional[String],
+    @(Schema @field)(
+      requiredMode = RequiredMode.NOT_REQUIRED,
+      allowableValues = Array(
+        "EI_TEHTY",
+        "LASNA_KOKO_LUKUVUOSI",
+        "POISSA_KOKO_LUKUVUOSI",
+        "EI_ILMOITTAUTUNUT",
+        "LASNA_SYKSY",
+        "POISSA_SYKSY",
+        "LASNA",
+        "POISSA"
+      )
+    )
+    @BeanProperty ilmoittautumisenTila: Optional[String]
+)
+object HakutoiveResponse {
+  def apply(hakutoive: Hakutoive): HakutoiveResponse =
+    this(
+      hakukohde = NimettyResponse(hakutoive.hakukohde),
+      tarjoaja = hakutoive.tarjoaja.map(NimettyResponse(_)).toJava,
+      koulutuksenAlkamiskausiUri = hakutoive.koulutuksenAlkamiskausiUri.toJava,
+      koulutuksenAlkamisvuosi = hakutoive.koulutuksenAlkamisvuosi.map(Integer.valueOf).toJava,
+      valinnanTila = hakutoive.valinnanTila.toJava,
+      vastaanotonTila = hakutoive.vastaanotonTila.toJava,
+      ilmoittautumisenTila = hakutoive.ilmoittautumisenTila.toJava
+    )
+}
+
+case class NimettyResponse(
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty oid: String,
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty nimi: KielistettyResponse
+)
+
+object NimettyResponse {
+  def apply(nimetty: Nimetty): NimettyResponse = NimettyResponse(nimetty.oid, KielistettyResponse(nimetty.nimi))
+}
+
+case class ValidationError(
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty status: Int,
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty message: String,
+    @(Schema @field)(requiredMode = RequiredMode.REQUIRED)
+    @BeanProperty details: java.util.List[String]
+)
+
+@JsonInclude(Include.NON_ABSENT)
+case class KielistettyResponse(
+    @(Schema @field)(requiredMode = RequiredMode.NOT_REQUIRED)
+    @BeanProperty fi: Optional[String],
+    @(Schema @field)(requiredMode = RequiredMode.NOT_REQUIRED)
+    @BeanProperty sv: Optional[String],
+    @(Schema @field)(requiredMode = RequiredMode.NOT_REQUIRED)
+    @BeanProperty en: Optional[String]
+)
+
+object KielistettyResponse {
+  def apply(kielistetty: Kielistetty): KielistettyResponse =
+    KielistettyResponse(
+      fi = kielistetty.get(Fi).toJava,
+      sv = kielistetty.get(Sv).toJava,
+      en = kielistetty.get(En).toJava
+    )
+}

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/Opiskelijavalintatieto.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/Opiskelijavalintatieto.scala
@@ -8,7 +8,7 @@ case class Opiskelijavalintatieto(
     syntymaaika: String,
     sukunimi: String,
     etunimet: String,
-    hakemukset: Iterable[Hakemus]
+    hakemukset: Seq[Hakemus]
 )
 
 case class Hakemus(
@@ -16,14 +16,14 @@ case class Hakemus(
     haku: Nimetty,
     haunKohdejoukko: Option[String],
     hakutapa: Option[String],
-    hakutoiveet: Iterable[Hakutoive]
+    hakutoiveet: Seq[Hakutoive]
 )
 
 case class Hakutoive(
     hakukohde: Nimetty,
     tarjoaja: Option[Nimetty],
     koulutuksenAlkamiskausiUri: Option[String],
-    koulutuksenAlkamisvuosi: Option[String],
+    koulutuksenAlkamisvuosi: Option[Int],
     valinnanTila: Option[String],
     vastaanotonTila: Option[String],
     ilmoittautumisenTila: Option[String]
@@ -38,7 +38,7 @@ case class OppijaRow(
     sukunimi: String,
     etunimet: String
 ) {
-  def asOpiskelijavalintatieto(hakemukset: Iterable[Hakemus]): Opiskelijavalintatieto = Opiskelijavalintatieto(
+  def asOpiskelijavalintatieto(hakemukset: Seq[Hakemus]): Opiskelijavalintatieto = Opiskelijavalintatieto(
     oppijanumero,
     hetu,
     syntymaaika,
@@ -60,7 +60,7 @@ case class HakemusRow(
     tarjoajanOid: Option[String],
     tarjoajanNimi: Kielistetty,
     koulutuksenAlkamiskausiuri: Option[String],
-    koulutuksenAlkamisvuosi: Option[String],
+    koulutuksenAlkamisvuosi: Option[Int],
     valinnanTila: Option[String],
     vastaanottoTila: Option[String],
     ilmoituksenTila: Option[String]

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/Opiskelijavalintatieto.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/Opiskelijavalintatieto.scala
@@ -1,0 +1,86 @@
+package fi.oph.ovara.backend.opiskelijavalintatieto
+
+import fi.oph.ovara.backend.domain.Kielistetty
+
+case class Opiskelijavalintatieto(
+    oppijanumero: String,
+    hetu: String,
+    syntymaaika: String,
+    sukunimi: String,
+    etunimet: String,
+    hakemukset: Iterable[Hakemus]
+)
+
+case class Hakemus(
+    hakemusOid: String,
+    haku: Nimetty,
+    haunKohdejoukko: Option[String],
+    hakutapa: Option[String],
+    hakutoiveet: Iterable[Hakutoive]
+)
+
+case class Hakutoive(
+    hakukohde: Nimetty,
+    tarjoaja: Option[Nimetty],
+    koulutuksenAlkamiskausiUri: Option[String],
+    koulutuksenAlkamisvuosi: Option[String],
+    valinnanTila: Option[String],
+    vastaanotonTila: Option[String],
+    ilmoittautumisenTila: Option[String]
+)
+
+case class Nimetty(oid: String, nimi: Kielistetty)
+
+case class OppijaRow(
+    oppijanumero: String,
+    hetu: String,
+    syntymaaika: String,
+    sukunimi: String,
+    etunimet: String
+) {
+  def asOpiskelijavalintatieto(hakemukset: Iterable[Hakemus]): Opiskelijavalintatieto = Opiskelijavalintatieto(
+    oppijanumero,
+    hetu,
+    syntymaaika,
+    sukunimi,
+    etunimet,
+    hakemukset
+  )
+}
+
+case class HakemusRow(
+    oppijanumero: String,
+    hakemusOid: String,
+    hakuOid: String,
+    hakuNimi: Kielistetty,
+    kohdejoukkoKoodiuri: Option[String],
+    hakutapakoodiuri: Option[String],
+    hakukohdeOid: String,
+    hakukohdeNimi: Kielistetty,
+    tarjoajanOid: Option[String],
+    tarjoajanNimi: Kielistetty,
+    koulutuksenAlkamiskausiuri: Option[String],
+    koulutuksenAlkamisvuosi: Option[String],
+    valinnanTila: Option[String],
+    vastaanottoTila: Option[String],
+    ilmoituksenTila: Option[String]
+) {
+
+  def asHakutoive: Hakutoive = Hakutoive(
+    Nimetty(hakukohdeOid, hakukohdeNimi),
+    tarjoajanOid.map(oid => Nimetty(oid, tarjoajanNimi)),
+    koulutuksenAlkamiskausiuri,
+    koulutuksenAlkamisvuosi,
+    valinnanTila,
+    vastaanottoTila,
+    ilmoituksenTila
+  )
+
+  def asHakemus(hakutoiveet: Seq[Hakutoive]): Hakemus = Hakemus(
+    hakemusOid,
+    Nimetty(hakuOid, hakuNimi),
+    kohdejoukkoKoodiuri,
+    hakutapakoodiuri,
+    hakutoiveet
+  )
+}

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoController.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoController.scala
@@ -1,67 +1,156 @@
 package fi.oph.ovara.backend.opiskelijavalintatieto
 
-import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.databind.ObjectMapper
 import fi.oph.ovara.backend.service.UserService
 import fi.oph.ovara.backend.utils.Constants.OPH_PAAKAYTTAJA_AUTHORITY
-import fi.oph.ovara.backend.utils.ControllerUtils.{getListParamAsScalaList, handleRequest}
+import fi.oph.ovara.backend.utils.ControllerUtils.getListParamAsScalaList
 import fi.oph.ovara.backend.utils.ParameterValidator.{validateOid, validateOidList}
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.{Content, Schema}
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.{Logger, LoggerFactory}
-import org.springframework.http.ResponseEntity
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.{HttpStatus, MediaType}
 import org.springframework.web.bind.annotation.{
+  ExceptionHandler,
   GetMapping,
   PostMapping,
   RequestBody,
   RequestMapping,
   RequestParam,
+  ResponseStatus,
   RestController
 }
+import org.springframework.web.server.ResponseStatusException
+
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.RichOption
 
 @RestController
 @RequestMapping(path = Array("api"))
-class OpiskelijavalintatietoController(
+class OpiskelijavalintatietoController @Autowired() (
     userService: UserService,
     opiskelijavalintatietoService: OpiskelijavalintatietoService
 ) {
   val LOG: Logger = LoggerFactory.getLogger(classOf[OpiskelijavalintatietoController])
 
-  private val mapper = new ObjectMapper()
-  mapper.registerModule(DefaultScalaModule)
-  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-  mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
-  mapper.configure(SerializationFeature.WRITE_SELF_REFERENCES_AS_NULL, true)
-
-  @GetMapping(path = Array("opiskelijavalintatiedot"))
+  @GetMapping(path = Array("opiskelijavalintatiedot"), produces = Array(MediaType.APPLICATION_JSON_VALUE))
+  @Operation(
+    summary = "Palauttaa pyydetyn oppijan opiskelijavalintatiedot.",
+    description =
+      "Palauttaa pyydetyn oppijan hakemukset ja hakemusten hakutoiveet. Jos näitä ei ole, palauttaa vain oppijan tiedot.",
+    responses = Array(
+      new ApiResponse(responseCode = "200", description = "Pyydetyn oppijan opiskelijavalintatiedot."),
+      new ApiResponse(
+        responseCode = "400",
+        description = "Validointivirhe",
+        content = Array(new Content(schema = new Schema(implementation = classOf[ValidationError])))
+      ),
+      new ApiResponse(responseCode = "403", description = "403 virhe", content = Array(new Content())),
+      new ApiResponse(responseCode = "404", description = "Henkilöä ei löytynyt", content = Array(new Content())),
+      new ApiResponse(
+        responseCode = "500",
+        description = "Muu virhe",
+        content = Array(new Content(schema = new Schema(implementation = classOf[String])))
+      )
+    )
+  )
   def opiskelijavalintatiedot(
       @RequestParam("ovara_oppijanumero", required = true) oppijanumero: String
-  ): ResponseEntity[String] = withPaakayttajaRole {
-    val errors = validateOid(Some(oppijanumero), "ovara_oppijanumero").toList
+  ): OpiskelijavalintatietoResponse = withPaakayttajaRole {
+    validate {
+      validateOid(Some(oppijanumero), "ovara_oppijanumero")
+    }
 
-    handleRequest(errors, mapper) {
-      opiskelijavalintatietoService.get(List(oppijanumero)).map(_.headOption.orNull)
+    handleRequest {
+      opiskelijavalintatietoService
+        .get(List(oppijanumero))
+        .map(_.headOption.map(OpiskelijavalintatietoResponse(_)).toJava.orElse(null))
     }
   }
 
   @PostMapping(path = Array("opiskelijavalintatiedot"))
-  def opiskelijavalintatiedot(@RequestBody oppijanumerot: java.util.Collection[String]): ResponseEntity[String] =
+  @Operation(
+    summary = "Palauttaa pyydettyjen oppijoiden opiskelijavalintatiedot.",
+    description =
+      "Palauttaa pyydettyjen oppijoiden hakemukset ja hakemusten hakutoiveet. Jos näitä ei ole, palauttaa vain oppijoiden tiedot. Palauttaa vain ne oppijat, joiden tiedot löytyvät järjestelmästä.",
+    responses = Array(
+      new ApiResponse(responseCode = "200", description = "Pyydettyjen oppijoiden opiskelijavalintatiedot."),
+      new ApiResponse(
+        responseCode = "400",
+        description = "Validointivirhe",
+        content = Array(new Content(schema = new Schema(implementation = classOf[ValidationError])))
+      ),
+      new ApiResponse(responseCode = "403", description = "403 virhe", content = Array(new Content())),
+      new ApiResponse(
+        responseCode = "500",
+        description = "Muu virhe",
+        content = Array(new Content(schema = new Schema(implementation = classOf[String])))
+      )
+    )
+  )
+  def opiskelijavalintatiedot(
+      @RequestBody oppijanumerot: java.util.Collection[String]
+  ): java.util.List[OpiskelijavalintatietoResponse] =
     withPaakayttajaRole {
       val numeroList = getListParamAsScalaList(oppijanumerot)
-      val errors     = validateOidList(numeroList, "oppijanumerot")
+      validate {
+        validateOidList(numeroList, "oppijanumerot")
+      }
 
-      handleRequest(errors, mapper) {
-        opiskelijavalintatietoService.get(numeroList)
+      handleRequest {
+        opiskelijavalintatietoService
+          .get(numeroList)
+          .map(_.map(OpiskelijavalintatietoResponse.apply).asJava)
       }
     }
 
-  private def withPaakayttajaRole(f: => ResponseEntity[String]): ResponseEntity[String] = {
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(Array(classOf[ValidationException]))
+  def validationException(ex: ValidationException): ValidationError = {
+    ValidationError(
+      status = HttpServletResponse.SC_BAD_REQUEST,
+      message = "virhe.validointi",
+      details = ex.validationErrors.asJava
+    )
+  }
+
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  @ExceptionHandler(Array(classOf[ApiException]))
+  def validationException(ex: ApiException): String = {
+    ObjectMapper().writeValueAsString(ex.errorMessage)
+  }
+
+  private def validate(f: => Iterable[String]): Unit = {
+    val errors = f
+    if (errors.nonEmpty) {
+      throw ValidationException(errors.toList)
+    }
+  }
+
+  private def handleRequest[T](block: => Either[String, T]): T = {
+    block match {
+      case Right(null) =>
+        throw ResponseStatusException(HttpStatus.NOT_FOUND)
+      case Right(result) =>
+        result
+      case Left(errorMessage) =>
+        // odottamattomista virheistä vain virheviesti
+        throw ApiException(errorMessage)
+    }
+  }
+
+  private def withPaakayttajaRole[T](f: => T): T = {
     val user = userService.getEnrichedUserDetails
 
     if (user.authorities.contains(OPH_PAAKAYTTAJA_AUTHORITY)) {
       f
     } else {
-      ResponseEntity.status(HttpServletResponse.SC_FORBIDDEN).build()
+      throw ResponseStatusException(HttpStatus.FORBIDDEN)
     }
-
   }
+
+  case class ValidationException(validationErrors: List[String]) extends RuntimeException
+  case class ApiException(errorMessage: String)                  extends RuntimeException
 }

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoController.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoController.scala
@@ -1,0 +1,67 @@
+package fi.oph.ovara.backend.opiskelijavalintatieto
+
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import fi.oph.ovara.backend.service.UserService
+import fi.oph.ovara.backend.utils.Constants.OPH_PAAKAYTTAJA_AUTHORITY
+import fi.oph.ovara.backend.utils.ControllerUtils.{getListParamAsScalaList, handleRequest}
+import fi.oph.ovara.backend.utils.ParameterValidator.{validateOid, validateOidList}
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.{
+  GetMapping,
+  PostMapping,
+  RequestBody,
+  RequestMapping,
+  RequestParam,
+  RestController
+}
+
+@RestController
+@RequestMapping(path = Array("api"))
+class OpiskelijavalintatietoController(
+    userService: UserService,
+    opiskelijavalintatietoService: OpiskelijavalintatietoService
+) {
+  val LOG: Logger = LoggerFactory.getLogger(classOf[OpiskelijavalintatietoController])
+
+  private val mapper = new ObjectMapper()
+  mapper.registerModule(DefaultScalaModule)
+  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+  mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+  mapper.configure(SerializationFeature.WRITE_SELF_REFERENCES_AS_NULL, true)
+
+  @GetMapping(path = Array("opiskelijavalintatiedot"))
+  def opiskelijavalintatiedot(
+      @RequestParam("ovara_oppijanumero", required = true) oppijanumero: String
+  ): ResponseEntity[String] = withPaakayttajaRole {
+    val errors = validateOid(Some(oppijanumero), "ovara_oppijanumero").toList
+
+    handleRequest(errors, mapper) {
+      opiskelijavalintatietoService.get(List(oppijanumero)).map(_.headOption.orNull)
+    }
+  }
+
+  @PostMapping(path = Array("opiskelijavalintatiedot"))
+  def opiskelijavalintatiedot(@RequestBody oppijanumerot: java.util.Collection[String]): ResponseEntity[String] =
+    withPaakayttajaRole {
+      val numeroList = getListParamAsScalaList(oppijanumerot)
+      val errors     = validateOidList(numeroList, "oppijanumerot")
+
+      handleRequest(errors, mapper) {
+        opiskelijavalintatietoService.get(numeroList)
+      }
+    }
+
+  private def withPaakayttajaRole(f: => ResponseEntity[String]): ResponseEntity[String] = {
+    val user = userService.getEnrichedUserDetails
+
+    if (user.authorities.contains(OPH_PAAKAYTTAJA_AUTHORITY)) {
+      f
+    } else {
+      ResponseEntity.status(HttpServletResponse.SC_FORBIDDEN).build()
+    }
+
+  }
+}

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoRepository.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoRepository.scala
@@ -1,0 +1,53 @@
+package fi.oph.ovara.backend.opiskelijavalintatieto
+
+import fi.oph.ovara.backend.repository.Extractors
+import fi.oph.ovara.backend.utils.RepositoryUtils
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.stereotype.Repository
+import slick.dbio.Effect
+import slick.jdbc.PostgresProfile.api.*
+import slick.sql.SqlStreamingAction
+
+@Repository
+class OpiskelijavalintatietoRepository extends Extractors {
+  val LOG: Logger = LoggerFactory.getLogger(classOf[OpiskelijavalintatietoRepository])
+
+  def selectOppijat(oppijanumerot: List[String]): SqlStreamingAction[Vector[OppijaRow], OppijaRow, Effect] = {
+    sql"""SELECT hlo.oppijanumero, hlo.hetu, hlo.syntymaaika, hlo.sukunimi, hlo.etunimet
+          FROM gen.gen_henkilo hlo
+          WHERE hlo.oppijanumero in (#${RepositoryUtils.makeListOfValuesQueryStr(oppijanumerot)})
+        """.as[OppijaRow]
+  }
+
+  def selectHakemukset(oppijanumerot: Seq[String]): SqlStreamingAction[Vector[HakemusRow], HakemusRow, Effect] = {
+    sql"""SELECT hlo.oppijanumero,
+                 ht.hakemus_oid,
+                 ht.haku_oid,
+                 h.haku_nimi_fi,
+                 h.haku_nimi_sv,
+                 h.haku_nimi_en,
+                 h.kohdejoukko_koodiuri,
+                 h.hakutapakoodiuri,
+                 ht.hakukohde_oid,
+                 hk.hakukohde_nimi_fi,
+                 hk.hakukohde_nimi_sv,
+                 hk.hakukohde_nimi_en,
+                 hk.jarjestyspaikka_oid,
+                 o.nimi_fi as org_nimi_fi,
+                 o.nimi_sv as org_nimi_sv,
+                 null as org_nimi_en,
+                 coalesce(hk.koulutuksen_alkamiskausiuri, h.koulutuksen_alkamiskausiuri) as koulutuksen_alkamiskausiuri,
+                 coalesce(hk.koulutuksen_alkamisvuosi, h.koulutuksen_alkamisvuosi) as koulutuksen_alkamisvuosi,
+                 ht.valintatieto,
+                 ht.vastaanottotieto,
+                 ht.ilmoittautumisen_tila
+          FROM gen.gen_henkilo hlo
+          INNER JOIN gen.gen_hakutoive ht ON ht.henkilo_oid = hlo.henkilo_oid
+          LEFT JOIN gen.gen_hakukohde hk ON ht.hakukohde_oid = hk.hakukohde_oid
+          LEFT JOIN gen.gen_haku h ON hk.haku_oid = h.haku_oid
+          LEFT JOIN gen.gen_organisaatio o ON hk.jarjestyspaikka_oid = o.organisaatio_oid
+          WHERE hlo.oppijanumero in (#${RepositoryUtils.makeListOfValuesQueryStr(oppijanumerot)})
+          ORDER BY hlo.oppijanumero, ht.hakemus_oid
+         """.as[HakemusRow]
+  }
+}

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoService.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoService.scala
@@ -32,7 +32,7 @@ class OpiskelijavalintatietoService(db: ReadOnlyDatabase, repository: Opiskelija
             _.groupBy(_.hakemusOid).values.map { rowsForHakemus =>
               val hakutoiveet = rowsForHakemus.map(_.asHakutoive)
               rowsForHakemus.head.asHakemus(hakutoiveet)
-            }
+            }.toSeq
           }
 
           oppija.asOpiskelijavalintatieto(hakemukset.getOrElse(Seq.empty))

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoService.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoService.scala
@@ -1,0 +1,45 @@
+package fi.oph.ovara.backend.opiskelijavalintatieto
+
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import fi.oph.ovara.backend.repository.ReadOnlyDatabase
+import org.slf4j.{Logger, LoggerFactory}
+import org.springframework.stereotype.Service
+
+import scala.util.Try
+
+@Service
+class OpiskelijavalintatietoService(db: ReadOnlyDatabase, repository: OpiskelijavalintatietoRepository) {
+  private val mapper = new ObjectMapper()
+  mapper.registerModule(DefaultScalaModule)
+  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+  mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+
+  val LOG: Logger = LoggerFactory.getLogger(classOf[OpiskelijavalintatietoService])
+
+  def get(oppijanumerot: List[String]): Either[String, Seq[Opiskelijavalintatieto]] = {
+    Try {
+      db.run(repository.selectOppijat(oppijanumerot), "selectHenkilot")
+    }.map {
+      case empty if empty.isEmpty => Nil
+      case oppijat =>
+        val hakemusRows = db
+          .run(repository.selectHakemukset(oppijat.map(_.oppijanumero)), "selectHakemukset")
+          .groupBy(_.oppijanumero)
+
+        oppijat.map { oppija =>
+          val hakemukset = hakemusRows.get(oppija.oppijanumero).map {
+            _.groupBy(_.hakemusOid).values.map { rowsForHakemus =>
+              val hakutoiveet = rowsForHakemus.map(_.asHakutoive)
+              rowsForHakemus.head.asHakemus(hakutoiveet)
+            }
+          }
+
+          oppija.asOpiskelijavalintatieto(hakemukset.getOrElse(Seq.empty))
+        }
+    }.toEither.left.map { exception =>
+      LOG.error("Error fetching hakukohteet", exception)
+      "virhe.tietokanta"
+    }
+  }
+}

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/raportointi/Controller.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/raportointi/Controller.scala
@@ -6,7 +6,7 @@ import fi.oph.ovara.backend.domain.UserResponse
 import fi.oph.ovara.backend.raportointi.dto.{RawHakeneetHyvaksytytVastaanottaneetParams, RawHakijatParams, RawKkHakeneetHyvaksytytVastaanottaneetParams, RawKkHakijatParams, RawKkKoulutuksetToteutuksetHakukohteetParams, RawKoulutuksetToteutuksetHakukohteetParams, buildHakeneetHyvaksytytVastaanottaneetAuditParams, buildHakijatAuditParams, buildKkHakeneetHyvaksytytVastaanottaneetAuditParams, buildKkHakijatAuditParams, buildKkKoulutuksetToteutuksetHakukohteetAuditParams, buildKoulutuksetToteutuksetHakukohteetAuditParams}
 import fi.oph.ovara.backend.service.{CommonService, HakeneetHyvaksytytVastaanottaneetService, KkHakeneetHyvaksytytVastaanottaneetService, KkHakijatService, KorkeakouluKoulutuksetToteutuksetHakukohteetService, KoulutuksetToteutuksetHakukohteetService, ToisenAsteenHakijatService, UserService}
 import fi.oph.ovara.backend.utils.AuditOperation.{HakeneetHyvaksytytVastaanottaneet, KkHakeneetHyvaksytytVastaanottaneet, KkHakijat, KorkeakouluKoulutuksetToteutuksetHakukohteet, KoulutuksetToteutuksetHakukohteet, ToisenAsteenHakijat}
-import fi.oph.ovara.backend.utils.ControllerUtils.{handleRequest, getListParamAsScalaList}
+import fi.oph.ovara.backend.utils.ControllerUtils.getListParamAsScalaList
 import fi.oph.ovara.backend.utils.ParameterValidator.{validateAlphanumeric, validateAlphanumericList, validateHakeneetHyvaksytytVastaanottaneetParams, validateHakijatParams, validateKkHakeneetHyvaksytytVastaanottaneetParams, validateKkHakijatParams, validateKkKoulutuksetToteutuksetHakukohteetParams, validateKoulutuksetToteutuksetHakukohteetParams, validateNumericList, validateOidList, validateOrganisaatioOid, validateOrganisaatioOidList}
 import fi.oph.ovara.backend.utils.{AuditLog, AuditLogObj, AuditOperation}
 import jakarta.servlet.http.{HttpServletRequest, HttpServletResponse}
@@ -51,6 +51,33 @@ class Controller(
   mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
   mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
 
+  private def handleRequest[T](
+                        validationErrors: List[String],
+                        mapper: ObjectMapper
+                      )(block: => Either[String, T]): ResponseEntity[String] = {
+    if (validationErrors.nonEmpty) {
+      // validointivirheistä palautetaan yksityiskohtia
+      val errorResponse = ErrorResponse(
+        status = HttpServletResponse.SC_BAD_REQUEST,
+        message = "virhe.validointi",
+        details = Some(validationErrors)
+      )
+      ResponseEntity
+        .status(HttpServletResponse.SC_BAD_REQUEST)
+        .body(mapper.writeValueAsString(errorResponse))
+    } else {
+      block match {
+        case Right(result) =>
+          ResponseEntity.ok(mapper.writeValueAsString(result))
+        case Left(errorMessage) =>
+          // odottamattomista virheistä vain virheviesti
+          ResponseEntity
+            .status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+            .body(mapper.writeValueAsString(errorMessage))
+      }
+    }
+  }
+  
   @GetMapping(path = Array("healthcheck"))
   def healthcheck = "Ovara application is running!"
 
@@ -348,7 +375,7 @@ class Controller(
     )
 
     val validationResult = validateKoulutuksetToteutuksetHakukohteetParams(params)
-    
+
     handleExcelRequest(
       validationErrors = validationResult.left.getOrElse(Nil),
       response = response,

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/raportointi/Controller.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/raportointi/Controller.scala
@@ -4,22 +4,22 @@ import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, Ser
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import fi.oph.ovara.backend.domain.UserResponse
 import fi.oph.ovara.backend.raportointi.dto.{RawHakeneetHyvaksytytVastaanottaneetParams, RawHakijatParams, RawKkHakeneetHyvaksytytVastaanottaneetParams, RawKkHakijatParams, RawKkKoulutuksetToteutuksetHakukohteetParams, RawKoulutuksetToteutuksetHakukohteetParams, buildHakeneetHyvaksytytVastaanottaneetAuditParams, buildHakijatAuditParams, buildKkHakeneetHyvaksytytVastaanottaneetAuditParams, buildKkHakijatAuditParams, buildKkKoulutuksetToteutuksetHakukohteetAuditParams, buildKoulutuksetToteutuksetHakukohteetAuditParams}
-import fi.oph.ovara.backend.service.*
+import fi.oph.ovara.backend.service.{CommonService, HakeneetHyvaksytytVastaanottaneetService, KkHakeneetHyvaksytytVastaanottaneetService, KkHakijatService, KorkeakouluKoulutuksetToteutuksetHakukohteetService, KoulutuksetToteutuksetHakukohteetService, ToisenAsteenHakijatService, UserService}
 import fi.oph.ovara.backend.utils.AuditOperation.{HakeneetHyvaksytytVastaanottaneet, KkHakeneetHyvaksytytVastaanottaneet, KkHakijat, KorkeakouluKoulutuksetToteutuksetHakukohteet, KoulutuksetToteutuksetHakukohteet, ToisenAsteenHakijat}
-import fi.oph.ovara.backend.utils.ParameterValidator.{strToOptionBoolean, validateAlphanumeric, validateAlphanumericList, validateHakeneetHyvaksytytVastaanottaneetParams, validateHakijatParams, validateKkHakeneetHyvaksytytVastaanottaneetParams, validateKkHakijatParams, validateKkKoulutuksetToteutuksetHakukohteetParams, validateKoulutuksetToteutuksetHakukohteetParams, validateNumericList, validateOid, validateOidList, validateOrganisaatioOid, validateOrganisaatioOidList}
+import fi.oph.ovara.backend.utils.ControllerUtils.{handleRequest, getListParamAsScalaList}
+import fi.oph.ovara.backend.utils.ParameterValidator.{validateAlphanumeric, validateAlphanumericList, validateHakeneetHyvaksytytVastaanottaneetParams, validateHakijatParams, validateKkHakeneetHyvaksytytVastaanottaneetParams, validateKkHakijatParams, validateKkKoulutuksetToteutuksetHakukohteetParams, validateKoulutuksetToteutuksetHakukohteetParams, validateNumericList, validateOidList, validateOrganisaatioOid, validateOrganisaatioOidList}
 import fi.oph.ovara.backend.utils.{AuditLog, AuditLogObj, AuditOperation}
 import jakarta.servlet.http.{HttpServletRequest, HttpServletResponse}
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.{HttpHeaders, MediaType, ResponseEntity}
 import org.springframework.security.web.csrf.CsrfToken
 import org.springframework.web.bind.annotation.{GetMapping, RequestMapping, RequestParam, RestController}
 import org.springframework.web.servlet.view.RedirectView
-import org.apache.poi.xssf.usermodel.XSSFWorkbook
 
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.util
 import scala.jdk.CollectionConverters.*
 
 case class ErrorResponse(
@@ -50,38 +50,6 @@ class Controller(
   mapper.registerModule(DefaultScalaModule)
   mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
   mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
-
-
-  private def getListParamAsScalaList(listParam: util.Collection[String]) = {
-    if (listParam == null) List() else listParam.asScala.toList
-  }
-
-  private def handleRequest[T](
-                        validationErrors: List[String],
-                        mapper: ObjectMapper
-                      )(block: => Either[String, T]): ResponseEntity[String] = {
-    if (validationErrors.nonEmpty) {
-      // validointivirheistä palautetaan yksityiskohtia
-      val errorResponse = ErrorResponse(
-        status = HttpServletResponse.SC_BAD_REQUEST,
-        message = "virhe.validointi",
-        details = Some(validationErrors)
-      )
-      ResponseEntity
-        .status(HttpServletResponse.SC_BAD_REQUEST)
-        .body(mapper.writeValueAsString(errorResponse))
-    } else {
-      block match {
-        case Right(result) =>
-          ResponseEntity.ok(mapper.writeValueAsString(result))
-        case Left(errorMessage) =>
-          // odottamattomista virheistä vain virheviesti
-          ResponseEntity
-            .status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
-            .body(mapper.writeValueAsString(errorMessage))
-      }
-    }
-  }
 
   @GetMapping(path = Array("healthcheck"))
   def healthcheck = "Ovara application is running!"

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/Extractors.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/Extractors.scala
@@ -242,7 +242,7 @@ trait Extractors extends GenericOvaraJsonFormats {
       tarjoajanOid = r.nextStringOption(),
       tarjoajanNimi = getKielistetty(r),
       koulutuksenAlkamiskausiuri = r.nextStringOption(),
-      koulutuksenAlkamisvuosi = r.nextStringOption(),
+      koulutuksenAlkamisvuosi = r.nextIntOption(),
       valinnanTila = r.nextStringOption(),
       vastaanottoTila = r.nextStringOption(),
       ilmoituksenTila = r.nextStringOption()

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/Extractors.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/repository/Extractors.scala
@@ -1,9 +1,9 @@
 package fi.oph.ovara.backend.repository
 
 import fi.oph.ovara.backend.domain.*
-import fi.oph.ovara.backend.utils.ParametriNimet
+import fi.oph.ovara.backend.opiskelijavalintatieto.{HakemusRow, OppijaRow}
 import fi.oph.ovara.backend.utils.ExtractorUtils.{extractArray, extractCommaSeparatedString, extractDateOption, extractHakuaika, extractKielistetty, extractKielistettyList, extractKoulutuksenAlkamisaika, extractMap, extractOpintojenlaajuus, extractValintatapajonot}
-import fi.oph.ovara.backend.utils.GenericOvaraJsonFormats
+import fi.oph.ovara.backend.utils.{GenericOvaraJsonFormats, ParametriNimet}
 import org.json4s.jackson.Serialization.read
 import slick.jdbc.*
 
@@ -212,6 +212,40 @@ trait Extractors extends GenericOvaraJsonFormats {
       puhelinnumero = r.nextStringOption(),
       sahkoposti = r.nextStringOption(),
       arvosanat = extractMap(r.nextStringOption())
+    )
+  )
+
+  implicit val getOppijaRow: GetResult[OppijaRow] = GetResult(r =>
+    OppijaRow(
+      oppijanumero = r.nextString(),
+      hetu = r.nextString(),
+      syntymaaika = r.nextString(),
+      sukunimi = r.nextString(),
+      etunimet = r.nextString(),
+    )
+  )
+
+  implicit val getKielistetty: GetResult[Kielistetty] = GetResult(r =>
+    Seq(Fi, Sv, En).flatMap(kieli => r.nextStringOption().map(kieli -> _)).toMap
+  )
+
+  implicit val getHakemus: GetResult[HakemusRow] = GetResult(r =>
+    HakemusRow(
+      oppijanumero = r.nextString(),
+      hakemusOid = r.nextString(),
+      hakuOid = r.nextString(),
+      hakuNimi = getKielistetty(r),
+      kohdejoukkoKoodiuri = r.nextStringOption(),
+      hakutapakoodiuri = r.nextStringOption(),
+      hakukohdeOid = r.nextString(),
+      hakukohdeNimi = getKielistetty(r),
+      tarjoajanOid = r.nextStringOption(),
+      tarjoajanNimi = getKielistetty(r),
+      koulutuksenAlkamiskausiuri = r.nextStringOption(),
+      koulutuksenAlkamisvuosi = r.nextStringOption(),
+      valinnanTila = r.nextStringOption(),
+      vastaanottoTila = r.nextStringOption(),
+      ilmoituksenTila = r.nextStringOption()
     )
   )
 

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/security/JdbcSessionMappingStorage.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/security/JdbcSessionMappingStorage.scala
@@ -35,7 +35,11 @@ class JdbcSessionMappingStorage(sessionRepository: SessionRepository[Session], s
   @Override
   def addSessionById(mappingId: String, session: HttpSession): Unit = {
     LOG.debug(s"Lisätään sessiomappaus, mappingId: $mappingId, sessionId: ${session.getId}")
-    val sql = sqlu"""INSERT INTO #$mappingTableName (mapped_ticket_id, virkailija_session_id) VALUES ($mappingId, ${session.getId}) ON CONFLICT (mapped_ticket_id) DO NOTHING"""
+    val sql =
+      sqlu"""INSERT INTO #$mappingTableName (mapped_ticket_id, virkailija_session_id)
+             SELECT $mappingId, ${session.getId} WHERE EXISTS (SELECT 1 FROM #$sessionTableName WHERE session_id = ${session.getId})
+             ON CONFLICT (mapped_ticket_id) DO NOTHING"""
+    LOG.debug(s"Add session query: ${sql.statements.head}")
     ovaraDatabase.run(sql, "addSessionById")
   }
 

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/security/SecurityConfig.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/security/SecurityConfig.scala
@@ -182,7 +182,7 @@ class SecurityConfig  {
         .anyRequest().fullyAuthenticated()
       )
       .csrf(csrf => csrf
-        .ignoringRequestMatchers("/api/healthcheck", "/api/csrf")
+        .ignoringRequestMatchers("/api/healthcheck", "/api/csrf", "/api/opiskelijavalintatiedot")
       )
       .exceptionHandling(exceptionHandling =>
         // corsin takia suoran cas uudelleenohjauksen sijaan palautetaan http 401 ja käli hoitaa forwardoinnin login apiin

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/Constants.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/Constants.scala
@@ -54,8 +54,9 @@ object Constants {
       "valinnan-aloituspaikat",
       "aloituspaikat",
     )
-    
-  val OPH_PAAKAYTTAJA_OID = "1.2.246.562.10.00000000001"
+
+  val OPH_PAAKAYTTAJA_OID       = "1.2.246.562.10.00000000001"
+  val OPH_PAAKAYTTAJA_AUTHORITY = s"ROLE_APP_OVARA-VIRKAILIJA_OPH_PAAKAYTTAJA_$OPH_PAAKAYTTAJA_OID"
 
   val KOULUTUSTOIMIJARAPORTTI = "koulutustoimijaraportti"
   val OPPILAITOSRAPORTTI      = "oppilaitosraportti"

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/ControllerUtils.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/ControllerUtils.scala
@@ -13,33 +13,4 @@ object ControllerUtils {
   def getListParamAsScalaList(listParam: util.Collection[String]): List[String] = {
     if (listParam == null) List() else listParam.asScala.toList
   }
-
-  def handleRequest[T](
-      validationErrors: List[String],
-      mapper: ObjectMapper
-  )(block: => Either[String, T]): ResponseEntity[String] = {
-    if (validationErrors.nonEmpty) {
-      // validointivirheistä palautetaan yksityiskohtia
-      val errorResponse = ErrorResponse(
-        status = HttpServletResponse.SC_BAD_REQUEST,
-        message = "virhe.validointi",
-        details = Some(validationErrors)
-      )
-      ResponseEntity
-        .status(HttpServletResponse.SC_BAD_REQUEST)
-        .body(mapper.writeValueAsString(errorResponse))
-    } else {
-      block match {
-        case Right(null) =>
-          ResponseEntity.notFound().build()
-        case Right(result) =>
-          ResponseEntity.ok(mapper.writeValueAsString(result))
-        case Left(errorMessage) =>
-          // odottamattomista virheistä vain virheviesti
-          ResponseEntity
-            .status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
-            .body(mapper.writeValueAsString(errorMessage))
-      }
-    }
-  }
 }

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/ControllerUtils.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/ControllerUtils.scala
@@ -1,0 +1,45 @@
+package fi.oph.ovara.backend.utils
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import fi.oph.ovara.backend.raportointi.ErrorResponse
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.ResponseEntity
+
+import java.util
+import scala.jdk.CollectionConverters.*
+
+object ControllerUtils {
+
+  def getListParamAsScalaList(listParam: util.Collection[String]): List[String] = {
+    if (listParam == null) List() else listParam.asScala.toList
+  }
+
+  def handleRequest[T](
+      validationErrors: List[String],
+      mapper: ObjectMapper
+  )(block: => Either[String, T]): ResponseEntity[String] = {
+    if (validationErrors.nonEmpty) {
+      // validointivirheistä palautetaan yksityiskohtia
+      val errorResponse = ErrorResponse(
+        status = HttpServletResponse.SC_BAD_REQUEST,
+        message = "virhe.validointi",
+        details = Some(validationErrors)
+      )
+      ResponseEntity
+        .status(HttpServletResponse.SC_BAD_REQUEST)
+        .body(mapper.writeValueAsString(errorResponse))
+    } else {
+      block match {
+        case Right(null) =>
+          ResponseEntity.notFound().build()
+        case Right(result) =>
+          ResponseEntity.ok(mapper.writeValueAsString(result))
+        case Left(errorMessage) =>
+          // odottamattomista virheistä vain virheviesti
+          ResponseEntity
+            .status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+            .body(mapper.writeValueAsString(errorMessage))
+      }
+    }
+  }
+}

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/ExtractorUtils.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/ExtractorUtils.scala
@@ -2,6 +2,7 @@ package fi.oph.ovara.backend.utils
 
 import fi.oph.ovara.backend.domain.*
 import org.json4s.jackson.Serialization.read
+import slick.jdbc.PositionedResult
 
 import java.sql.Date
 import java.time.LocalDate

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/JsonConfiguration.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/JsonConfiguration.scala
@@ -1,0 +1,20 @@
+package fi.oph.ovara.backend.utils
+
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.springframework.context.annotation.{Bean, Configuration}
+
+@Configuration
+class JsonConfiguration {
+
+  @Bean
+  def objectMapper(): ObjectMapper = {
+    val mapper = new ObjectMapper()
+    mapper.registerModule(DefaultScalaModule)
+    mapper.registerModule(new Jdk8Module())
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+    mapper
+  }
+}

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/RepositoryUtils.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/RepositoryUtils.scala
@@ -24,7 +24,7 @@ object RepositoryUtils {
     (alkamiskaudetAndVuodet, henkilokohtainenSuunnitelma, eiAlkamiskautta)
   }
 
-  def makeListOfValuesQueryStr(values: List[String]): String = {
+  def makeListOfValuesQueryStr(values: Seq[String]): String = {
     s"${values.map(s => s"'$s'").mkString(", ")}"
   }
 

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/ControllerSpec.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/ControllerSpec.scala
@@ -2,15 +2,14 @@ package fi.oph.ovara.backend
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import fi.oph.ovara.backend.raportointi.{Controller, ErrorResponse}
+import fi.oph.ovara.backend.raportointi.Controller
 import fi.oph.ovara.backend.service.*
 import fi.oph.ovara.backend.utils.{AuditLog, AuditOperation}
 import fi.vm.sade.auditlog.*
 import jakarta.servlet.http.{HttpServletRequest, HttpServletResponse}
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
-import org.json4s.jackson.JsonMethods.mapper
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
-import org.mockito.ArgumentMatchers.{any, argThat}
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/OvaraBackendApplicationTests.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/OvaraBackendApplicationTests.scala
@@ -20,7 +20,6 @@ class OvaraBackendApplicationTests {
     private val mvc: MockMvc = null
 
     @Test
-    @throws[Exception]
     def get200ResponseFromHealthcheckUnautheticated(): Unit = {
         mvc.perform(MockMvcRequestBuilders.get("/api/healthcheck").accept(MediaType.APPLICATION_JSON))
           .andExpect(status.isOk)
@@ -28,7 +27,6 @@ class OvaraBackendApplicationTests {
     }
 
     @Test
-    @throws[Exception]
     def get401ResponseFromAuthenticatedApi(): Unit = {
         mvc.perform(MockMvcRequestBuilders.get("/api/alkamisvuodet").accept(MediaType.APPLICATION_JSON))
           .andExpect(status.isUnauthorized)

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoControllerTest.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoControllerTest.scala
@@ -65,6 +65,13 @@ class OpiskelijavalintatietoControllerTest extends OpiskelijavalintatietoTestUti
     }
 
     @Test
+    def returns500WhenDatabaseError(): Unit = {
+      get()
+        .andExpect(status().isInternalServerError)
+        .andExpect(content().json("\"virhe.tietokanta\""))
+    }
+
+    @Test
     def returnsNotFoundWhenUserNotFound(): Unit = {
       initSchema()
 
@@ -209,7 +216,7 @@ class OpiskelijavalintatietoControllerTest extends OpiskelijavalintatietoTestUti
       |        }
       |      },
       |      "koulutuksenAlkamiskausiUri" : "kausi_s#1",
-      |      "koulutuksenAlkamisvuosi" : "2022",
+      |      "koulutuksenAlkamisvuosi" : 2022,
       |      "valinnanTila" : null,
       |      "vastaanotonTila" : null,
       |      "ilmoittautumisenTila" : null

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoControllerTest.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoControllerTest.scala
@@ -1,0 +1,219 @@
+package fi.oph.ovara.backend.opiskelijavalintatieto
+
+import fi.oph.ovara.backend.repository.ReadOnlyDatabase
+import org.junit.jupiter.api.{Nested, Test}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.{WithAnonymousUser, WithMockUser}
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.{MockMvc, ResultActions}
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.{content, status}
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles(Array("test"))
+@WithMockUser(username = "testuser", roles = Array("APP_OVARA-VIRKAILIJA_OPH_PAAKAYTTAJA_1.2.246.562.10.00000000001"))
+class OpiskelijavalintatietoControllerTest extends OpiskelijavalintatietoTestUtils {
+  @Autowired
+  private val mvc: MockMvc = null
+
+  @Autowired
+  override val db: ReadOnlyDatabase = null
+
+  @Nested
+  class Get {
+    private def get(oppijanumero: String = "1.2.246.562.24.9") = {
+      mvc.perform(
+        MockMvcRequestBuilders
+          .get("/api/opiskelijavalintatiedot")
+          .param("ovara_oppijanumero", oppijanumero)
+          .accept(MediaType.APPLICATION_JSON)
+      )
+    }
+
+    @Test
+    @WithAnonymousUser
+    def returns401WhenNoUser(): Unit = {
+      get()
+        .andExpect(status.isUnauthorized)
+        .andExpect(content.string(""))
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = Array("USER"))
+    def returns403WhenUserMissingRole(): Unit = {
+      get()
+        .andExpect(status.isForbidden)
+        .andExpect(content.string(""))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = Array("not-oid", "1.2", "1.2.246", "1.2.246.1", "1.2.247.1.1"))
+    def returns400WhenParameterNotOid(oppijanumero: String): Unit = {
+      get(oppijanumero)
+        .andExpect(status.isBadRequest)
+        .andExpect(
+          content.json(
+            """{"status": 400, "message": "virhe.validointi", "details": ["ovara_oppijanumero.invalid.oid"] }"""
+          )
+        )
+    }
+
+    @Test
+    def returnsNotFoundWhenUserNotFound(): Unit = {
+      initSchema()
+
+      get()
+        .andExpect(status.isNotFound)
+        .andExpect(content.string(""))
+    }
+
+    @Test
+    def returnsHenkiloWhenNoHakemukset(): Unit = {
+      initSchema()
+      insertHenkilo()
+
+      get()
+        .andExpect(status.isOk)
+        .andExpect(content.json(expectedOppija))
+    }
+
+    @Test
+    def returnsHenkiloWithHakemukset(): Unit = {
+      initSchema()
+      insertHenkilo()
+      insertHakemusData()
+
+      get()
+        .andExpect(status.isOk)
+        .andExpect(content.json(expectedOppijaWithHakemukset))
+    }
+  }
+
+  @Nested
+  class Post {
+    private def post(oppijanumero: String = "1.2.246.562.24.9"): ResultActions =
+      mvc.perform(
+        MockMvcRequestBuilders
+          .post("/api/opiskelijavalintatiedot")
+          .content(s"""["$oppijanumero"]""")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+      )
+
+    @Test
+    @WithAnonymousUser
+    def returns401WhenNoUser(): Unit = {
+      post()
+        .andExpect(status.isUnauthorized)
+        .andExpect(content.string(""))
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = Array("USER"))
+    def returns403WhenUserMissingRole(): Unit = {
+      post()
+        .andExpect(status.isForbidden)
+        .andExpect(content.string(""))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = Array("not-oid", "1.2", "1.2.246", "1.2.246.1", "1.2.247.1.1"))
+    def returns400WhenParameterNotOid(oppijanumero: String): Unit = {
+      post(oppijanumero)
+        .andExpect(status.isBadRequest)
+        .andExpect(
+          content.json("""{"status": 400, "message": "virhe.validointi", "details": ["oppijanumerot.invalid.oid"] }""")
+        )
+    }
+
+    @Test
+    def returnsEmptyListWhenUserNotFound(): Unit = {
+      initSchema()
+
+      post()
+        .andExpect(status.isOk)
+        .andExpect(content.json("[]"))
+    }
+
+    @Test
+    def returnsHenkiloWhenNoHakemukset(): Unit = {
+      initSchema()
+      insertHenkilo()
+
+      post()
+        .andExpect(status.isOk)
+        .andExpect(content.json(s"""[$expectedOppija]""".stripMargin))
+    }
+
+    @Test
+    def returnsHenkiloWithHakemukset(): Unit = {
+      initSchema()
+      insertHenkilo()
+      insertHakemusData()
+
+      post()
+        .andExpect(status.isOk)
+        .andExpect(content.json(s"[$expectedOppijaWithHakemukset]"))
+    }
+  }
+
+  private val expectedOppija =
+    """{
+      |  "oppijanumero" : "1.2.246.562.24.9",
+      |  "hetu" : "080872W943L",
+      |  "syntymaaika" : "1977-01-15",
+      |  "sukunimi" : "Testinen",
+      |  "etunimet" : "Toivo Taneli",
+      |  "hakemukset" : [ ]
+      |}""".stripMargin
+
+  private val expectedOppijaWithHakemukset =
+    """{
+      |  "oppijanumero" : "1.2.246.562.24.9",
+      |  "hetu" : "080872W943L",
+      |  "syntymaaika" : "1977-01-15",
+      |  "sukunimi" : "Testinen",
+      |  "etunimet" : "Toivo Taneli",
+      |  "hakemukset" : [ {
+      |    "hakemusOid" : "1.2.246.562.11.580",
+      |    "haku" : {
+      |      "oid" : "1.2.246.562.29.001",
+      |      "nimi" : {
+      |        "fi" : "Korkeakoulujen yhteishaku",
+      |        "sv" : "Högskolornas gemensamma",
+      |        "en" : "Joint application to higher education"
+      |      }
+      |    },
+      |    "haunKohdejoukko" : "haunkohdejoukko_12#1",
+      |    "hakutapa" : "hakutapa_01#1",
+      |    "hakutoiveet" : [ {
+      |      "hakukohde" : {
+      |        "oid" : "1.2.246.562.20.012",
+      |        "nimi" : {
+      |          "fi" : "Maisterihaku",
+      |          "sv" : "Magisteransökan",
+      |          "en" : "Master's Admission"
+      |        }
+      |      },
+      |      "tarjoaja" : {
+      |        "oid" : "1.2.246.562.10.486",
+      |        "nimi" : {
+      |          "fi" : "Bio- ja ympäristötieteellinen tiedekunta",
+      |          "sv" : "Bio- och miljövetenskapliga fakulteten"
+      |        }
+      |      },
+      |      "koulutuksenAlkamiskausiUri" : "kausi_s#1",
+      |      "koulutuksenAlkamisvuosi" : "2022",
+      |      "valinnanTila" : null,
+      |      "vastaanotonTila" : null,
+      |      "ilmoittautumisenTila" : null
+      |    } ]
+      |  } ]
+      |}""".stripMargin
+}

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoServiceTest.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoServiceTest.scala
@@ -44,12 +44,11 @@ class OpiskelijavalintatietoServiceTest extends AnyFlatSpec with Matchers with O
 
     val response = service.get(List(OPPIJANUMERO))
 
-    val head = getOnlyOppija(response)
-    assert(head.hakemukset.size == 1)
-    assert(head.hakemukset.head.haku.oid == HAKU_OID)
-    assert(head.hakemukset.head.haku.nimi.isEmpty)
-    assert(head.hakemukset.head.haunKohdejoukko.isEmpty)
-    assert(head.hakemukset.head.hakutapa.isEmpty)
+    val hakemus = getOnlyHakemus(response)
+    assert(hakemus.haku.oid == HAKU_OID)
+    assert(hakemus.haku.nimi.isEmpty)
+    assert(hakemus.haunKohdejoukko.isEmpty)
+    assert(hakemus.hakutapa.isEmpty)
   }
 
   it should "return hakemus without hakukohde names when hakukohde not found" in {
@@ -95,10 +94,10 @@ class OpiskelijavalintatietoServiceTest extends AnyFlatSpec with Matchers with O
     assert(oppija.hakemukset.head.hakutoiveet.size == 2)
     val hakutoiveWithHakukohdeValues = oppija.hakemukset.head.hakutoiveet.find(_.hakukohde.oid == HAKUKOHDE_OID).get
     assert(hakutoiveWithHakukohdeValues.koulutuksenAlkamiskausiUri.contains("kausi_s#1"))
-    assert(hakutoiveWithHakukohdeValues.koulutuksenAlkamisvuosi.contains("2022"))
+    assert(hakutoiveWithHakukohdeValues.koulutuksenAlkamisvuosi.contains(2022))
     val hakutoiveWithHakuValues = oppija.hakemukset.head.hakutoiveet.find(_.hakukohde.oid == otherHakukohdeOid).get
     assert(hakutoiveWithHakuValues.koulutuksenAlkamiskausiUri.contains("kausi_k#1"))
-    assert(hakutoiveWithHakuValues.koulutuksenAlkamisvuosi.contains("2023"))
+    assert(hakutoiveWithHakuValues.koulutuksenAlkamisvuosi.contains(2023))
   }
 
   it should "returns alkamiskausi and alkamisvuosi as nulls when both hakukohde and haku don't have them" in {
@@ -143,10 +142,16 @@ class OpiskelijavalintatietoServiceTest extends AnyFlatSpec with Matchers with O
     response.toOption.get.head
   }
 
+  private def getOnlyHakemus(response: Either[String, Seq[Opiskelijavalintatieto]]): Hakemus = {
+    val oppija = getOnlyOppija(response)
+    assert(oppija.hakemukset.size == 1)
+    oppija.hakemukset.head
+  }
+
   private def getOnlyHakutoive(response: Either[String, Seq[Opiskelijavalintatieto]]): Hakutoive = {
-    val head = getOnlyOppija(response)
-    assert(head.hakemukset.flatMap(_.hakutoiveet).size == 1)
-    head.hakemukset.head.hakutoiveet.head
+    val hakemus = getOnlyHakemus(response)
+    assert(hakemus.hakutoiveet.size == 1)
+    hakemus.hakutoiveet.head
   }
 
 }

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoServiceTest.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoServiceTest.scala
@@ -1,0 +1,152 @@
+package fi.oph.ovara.backend.opiskelijavalintatieto
+
+import fi.oph.ovara.backend.repository.ReadOnlyDatabase
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.{ActiveProfiles, TestContextManager}
+import slick.jdbc.H2Profile.api.*
+
+@SpringBootTest
+@ActiveProfiles(Array("test"))
+class OpiskelijavalintatietoServiceTest extends AnyFlatSpec with Matchers with OpiskelijavalintatietoTestUtils {
+
+  @Autowired
+  override val db: ReadOnlyDatabase = null
+
+  @Autowired
+  private val service: OpiskelijavalintatietoService = null
+
+  new TestContextManager(this.getClass).prepareTestInstance(this)
+
+  "get" should "return error string when there's a db error" in {
+    val response = service.get(List("1.2.246.562.24.9"))
+
+    assert(response.isLeft)
+    assert(response.left.toOption.get == "virhe.tietokanta")
+  }
+
+  it should "return only oppijat that really exist" in {
+    initSchema()
+    insertHenkilo()
+    insertHenkilo("1.2.246.562.24.999")
+
+    val response = service.get(List(OPPIJANUMERO, "1.2.246.562.24.8"))
+
+    val head = getOnlyOppija(response)
+    assert(head.oppijanumero == OPPIJANUMERO)
+  }
+
+  it should "return hakemus without haku names when haku not found" in {
+    initAndInsert()
+    db.run(sqlu"""DELETE FROM gen.gen_haku WHERE haku_oid = $HAKU_OID""", "Delete haku row")
+
+    val response = service.get(List(OPPIJANUMERO))
+
+    val head = getOnlyOppija(response)
+    assert(head.hakemukset.size == 1)
+    assert(head.hakemukset.head.haku.oid == HAKU_OID)
+    assert(head.hakemukset.head.haku.nimi.isEmpty)
+    assert(head.hakemukset.head.haunKohdejoukko.isEmpty)
+    assert(head.hakemukset.head.hakutapa.isEmpty)
+  }
+
+  it should "return hakemus without hakukohde names when hakukohde not found" in {
+    initAndInsert()
+    db.run(sqlu"""DELETE FROM gen.gen_hakukohde WHERE hakukohde_oid = $HAKUKOHDE_OID""", "Delete hakukohde row")
+
+    val response = service.get(List(OPPIJANUMERO))
+
+    val hakutoive = getOnlyHakutoive(response)
+    assert(hakutoive.hakukohde.oid == HAKUKOHDE_OID)
+    assert(hakutoive.hakukohde.nimi.isEmpty)
+  }
+
+  it should "return hakemus without tarjoaja names when tarjoaja not found" in {
+    initAndInsert()
+    db.run(
+      sqlu"""DELETE FROM gen.gen_organisaatio WHERE organisaatio_oid = $ORGANISAATIO_OID""",
+      "Delete organisaatio row"
+    )
+
+    val response = service.get(List(OPPIJANUMERO))
+
+    val hakutoive = getOnlyHakutoive(response)
+    assert(hakutoive.tarjoaja.contains(Nimetty(ORGANISAATIO_OID, Map.empty)))
+  }
+
+  it should "read alkamiskausi and alkamisvuosi first from hakukohde and then from haku" in {
+    initAndInsert()
+    val otherHakukohdeOid = "1.2.246.562.20.901"
+    db.run(
+      sqlu"""INSERT INTO gen.gen_hakukohde VALUES ($otherHakukohdeOid, $HAKU_OID, 'Maisterihaku', 'Magisteransökan', 'Master''s Admission', $ORGANISAATIO_OID, null, null)""",
+      "Insert hakukohde without alkamiskausi and vuosi"
+    )
+    db.run(
+      sqlu"""INSERT INTO gen.gen_hakutoive VALUES ($HAKEMUS_OID, $otherHakukohdeOid, $HAKU_OID, $OPPIJANUMERO, null, null, null)""",
+      "Insert hakutoive for hakukohde without alkamiskausi and vuosi"
+    )
+
+    val response = service.get(List(OPPIJANUMERO))
+
+    val oppija = getOnlyOppija(response)
+    assert(oppija.hakemukset.size == 1)
+    assert(oppija.hakemukset.head.hakutoiveet.size == 2)
+    val hakutoiveWithHakukohdeValues = oppija.hakemukset.head.hakutoiveet.find(_.hakukohde.oid == HAKUKOHDE_OID).get
+    assert(hakutoiveWithHakukohdeValues.koulutuksenAlkamiskausiUri.contains("kausi_s#1"))
+    assert(hakutoiveWithHakukohdeValues.koulutuksenAlkamisvuosi.contains("2022"))
+    val hakutoiveWithHakuValues = oppija.hakemukset.head.hakutoiveet.find(_.hakukohde.oid == otherHakukohdeOid).get
+    assert(hakutoiveWithHakuValues.koulutuksenAlkamiskausiUri.contains("kausi_k#1"))
+    assert(hakutoiveWithHakuValues.koulutuksenAlkamisvuosi.contains("2023"))
+  }
+
+  it should "returns alkamiskausi and alkamisvuosi as nulls when both hakukohde and haku don't have them" in {
+    initAndInsert()
+    val otherHakukohdeOid = "1.2.246.562.20.901"
+    db.run(
+      sqlu"""UPDATE gen.gen_haku SET koulutuksen_alkamiskausiuri = null, koulutuksen_alkamisvuosi = null""",
+      "Remove alkamiskausi and vuosi from haku"
+    )
+    db.run(
+      sqlu"""UPDATE gen.gen_hakukohde SET koulutuksen_alkamiskausiuri = null, koulutuksen_alkamisvuosi = null""",
+      "Remove alkamiskausi and vuosi from hakukohde"
+    )
+
+    val response = service.get(List(OPPIJANUMERO))
+
+    val hakutoive = getOnlyHakutoive(response)
+    assert(hakutoive.koulutuksenAlkamiskausiUri.isEmpty)
+    assert(hakutoive.koulutuksenAlkamisvuosi.isEmpty)
+  }
+
+  it should "return tila information when set on the hakutoive" in {
+    db.run(
+      sqlu"""UPDATE gen.gen_hakutoive SET
+             valintatieto = 'HYVAKSYTTY',
+             vastaanottotieto = 'VASTAANOTTANUT_SITOVASTI',
+             ilmoittautumisen_tila = 'LASNA_KOKO_LUKUVUOSI'""",
+      "Set tila information for hakutoive"
+    )
+
+    val response = service.get(List(OPPIJANUMERO))
+
+    val hakutoive = getOnlyHakutoive(response)
+    assert(hakutoive.valinnanTila.contains("HYVAKSYTTY"))
+    assert(hakutoive.vastaanotonTila.contains("VASTAANOTTANUT_SITOVASTI"))
+    assert(hakutoive.ilmoittautumisenTila.contains("LASNA_KOKO_LUKUVUOSI"))
+  }
+
+  private def getOnlyOppija(response: Either[String, Seq[Opiskelijavalintatieto]]): Opiskelijavalintatieto = {
+    assert(response.isRight)
+    assert(response.toOption.get.size == 1)
+    response.toOption.get.head
+  }
+
+  private def getOnlyHakutoive(response: Either[String, Seq[Opiskelijavalintatieto]]): Hakutoive = {
+    val head = getOnlyOppija(response)
+    assert(head.hakemukset.flatMap(_.hakutoiveet).size == 1)
+    head.hakemukset.head.hakutoiveet.head
+  }
+
+}

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoTestUtils.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/opiskelijavalintatieto/OpiskelijavalintatietoTestUtils.scala
@@ -1,0 +1,80 @@
+package fi.oph.ovara.backend.opiskelijavalintatieto
+
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import fi.oph.ovara.backend.repository.ReadOnlyDatabase
+import slick.jdbc.H2Profile.api.*
+
+trait OpiskelijavalintatietoTestUtils {
+  val db: ReadOnlyDatabase
+
+  val OPPIJANUMERO     = "1.2.246.562.24.9"
+  val HAKEMUS_OID      = "1.2.246.562.11.580"
+  val HAKU_OID         = "1.2.246.562.29.001"
+  val HAKUKOHDE_OID    = "1.2.246.562.20.012"
+  val ORGANISAATIO_OID = "1.2.246.562.10.486"
+
+  val mapper = new ObjectMapper()
+  mapper.registerModule(DefaultScalaModule)
+  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+  mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+  mapper.configure(SerializationFeature.WRITE_SELF_REFERENCES_AS_NULL, true)
+
+  def initAndInsert(): Unit = {
+    initSchema()
+    insertHenkilo()
+    insertHakemusData()
+  }
+
+  def initSchema(): Unit = {
+    db.run(sqlu"""DROP ALL OBJECTS""", "Drop everything")
+    db.run(sqlu"""CREATE SCHEMA gen""", "Create gen schema")
+    db.run(
+      sqlu"""CREATE TABLE gen.gen_henkilo (oppijanumero text, henkilo_oid text, etunimet text, sukunimi text, hetu text, syntymaaika date)""",
+      "Create henkilo table"
+    )
+    db.run(
+      sqlu"""CREATE TABLE gen.gen_hakutoive (hakemus_oid text, hakukohde_oid text, haku_oid text, henkilo_oid text, valintatieto text, vastaanottotieto text, ilmoittautumisen_tila text)""",
+      "Create hakutoive table"
+    )
+    db.run(
+      sqlu"""CREATE TABLE gen.gen_hakukohde (hakukohde_oid text, haku_oid text, hakukohde_nimi_fi text, hakukohde_nimi_sv text, hakukohde_nimi_en text, jarjestyspaikka_oid text, koulutuksen_alkamiskausiuri text, koulutuksen_alkamisvuosi integer)""",
+      "Create hakukohde table"
+    )
+    db.run(
+      sqlu"""CREATE TABLE gen.gen_haku (haku_oid text, haku_nimi_fi text, haku_nimi_sv text, haku_nimi_en text, kohdejoukko_koodiuri text, hakutapakoodiuri text, koulutuksen_alkamiskausiuri text, koulutuksen_alkamisvuosi integer)""",
+      "Create hakukohde table"
+    )
+    db.run(
+      sqlu"""CREATE TABLE gen.gen_organisaatio (organisaatio_oid text, nimi_fi text, nimi_sv text)""",
+      "Create hakukohde table"
+    )
+  }
+
+  def insertHenkilo(oppijanumero: String = OPPIJANUMERO): Unit = {
+    db.run(
+      sqlu"""INSERT INTO gen.gen_henkilo VALUES ($oppijanumero, $oppijanumero, 'Toivo Taneli' , 'Testinen', '080872W943L', '1977-01-15')""",
+      "Insert test henkilo"
+    )
+  }
+
+  def insertHakemusData(): Unit = {
+    db.run(
+      sqlu"""INSERT INTO gen.gen_haku VALUES ($HAKU_OID, 'Korkeakoulujen yhteishaku', 'Högskolornas gemensamma', 'Joint application to higher education', 'haunkohdejoukko_12#1', 'hakutapa_01#1', 'kausi_k#1', 2023)""",
+      "Insert test haku"
+    )
+    db.run(
+      sqlu"""INSERT INTO gen.gen_hakukohde VALUES ($HAKUKOHDE_OID, $HAKU_OID, 'Maisterihaku', 'Magisteransökan', 'Master''s Admission', $ORGANISAATIO_OID, 'kausi_s#1', 2022)""",
+      "Insert test hakukohde"
+    )
+    db.run(
+      sqlu"""INSERT INTO gen.gen_hakutoive VALUES ($HAKEMUS_OID, $HAKUKOHDE_OID, $HAKU_OID, $OPPIJANUMERO, null, null, null)""",
+      "Insert test hakutoive"
+    )
+    db.run(
+      sqlu"""INSERT INTO gen.gen_organisaatio VALUES ($ORGANISAATIO_OID, 'Bio- ja ympäristötieteellinen tiedekunta', 'Bio- och miljövetenskapliga fakulteten')""",
+      "Insert test organisaatio"
+    )
+  }
+
+}


### PR DESCRIPTION
Hakee oppijoiden opiskelijavalintatiedot Ovaran yleiskäyttöisestä gen-skeemasta.

Hakee oppijoiden tiedot oppijanumeron perusteella, sisältäen myös
mahdolliset muut henkilö-oidit, jos oppijalla on näitä useita.

Kaksi eri endpointtia: GET-endpoint yksittäisen oppijen tietojen
hakemiseen ja POST-endpoint, josta voi hakea tiedot monelle oppijalle
samalla kertaa. Rajapintojen käyttämiseen tarvitsee OPH:n
pääkäyttäjäoikeuden Ovaraan.

Toiminnalisuudet tehty omaan pakettiinsa, kun ne ei liity kovin vahvasti
muuhun palvelun toiminnallisuuteen, eli raporttien muodostamiseen.
Joitain metodeja on siirretty util-objekteihin, jotta niitä voi käyttää
sekä raportoinnista että uudesta paketista.

Samalla päivitetään github-actionit Node v24:sta tukeviin versioihin ja
päivitetään haavoittuvat riippuvuudet.