### PR TITLE
OY-5676 Valpas-rajapinnan hakuaikojen korjaus

### DIFF
--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/valpas/ValpasFormats.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/valpas/ValpasFormats.scala
@@ -1,14 +1,21 @@
 package fi.oph.ovara.backend.valpas
 
-import fi.oph.ovara.backend.utils.Constants.ISO_LOCAL_DATE_TIME_FORMATTER
 import fi.oph.ovara.backend.utils.GenericOvaraJsonFormats
 import org.json4s.JsonAST.{JObject, JString}
 import org.json4s.MonadicJValue.jvalueToMonadic
 import org.json4s.{CustomSerializer, Extraction, Formats, JValue}
 
 import java.time.LocalDateTime
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.time.temporal.ChronoField
 
 trait ValpasFormats extends GenericOvaraJsonFormats {
+
+  private val alkaaFormatter: DateTimeFormatter = new DateTimeFormatterBuilder()
+    .appendPattern("uuuu-MM-dd['T'HH:mm]")
+    .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+    .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+    .toFormatter()
 
   override implicit def jsonFormats: Formats = genericOvaraFormats + valpasHakuaikaSerializer
 
@@ -17,8 +24,10 @@ trait ValpasFormats extends GenericOvaraJsonFormats {
       { case s: JObject =>
         implicit def formats: Formats = jsonFormats
 
+        // Päättymispäivää ei käytetä, joten oletetaan kaikille ajoille alkuajaksi
+        // vuorokauden ensimmäinen hetki.
         def parseLocalDateTime(str: String) = {
-          Option(LocalDateTime.from(ISO_LOCAL_DATE_TIME_FORMATTER.parse(str)))
+          Option(LocalDateTime.from(alkaaFormatter.parse(str)))
         }
 
         val alkaa = s \ "alkaa" match {

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/valpas/ValpasTestUtils.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/valpas/ValpasTestUtils.scala
@@ -47,7 +47,7 @@ trait ValpasTestUtils {
           'Gemensamma',
           'Joint application',
           'haunkohdejoukko_11#1',
-          '[{"alkaa": "2024-08-31T23:59", "paattyy": "2027-08-31T23:59"},{"alkaa": "2026-08-31T23:59", "paattyy": "2027-09-30T23:59"},{"alkaa": "2022-08-31T23:59", "paattyy": "2023-08-31T23:59"}]'
+          '[{"alkaa": "2024-08-31T23:59", "paattyy": "2027-08-31T23:59"},{"alkaa": "2026-08-31", "paattyy": "2027-09-30"},{"alkaa": "2022-08-31T23:59", "paattyy": "2023-08-31T23:59"}]'
           )""",
       "Insert test haku"
     )


### PR DESCRIPTION
Muutetaan hakuaikojen parseaminen toimimaan riippumatta siitä, onko hakuajassa kellonaikaa mukana tai ei.

Tuotannossa `gen.gen_haku.hakuajat` sisältää sekaisin rivejä, joissa alkamis- ja päättymispäivässä on kellonaika mukana ja sellasia joissa kellonaikaa ei ole. QA:lla oli vain kellonajallisia rivejä.