### PR TITLE
OY-5647: lisää null-käsittely valintatapajonon kentille

### DIFF
--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/ExtractorUtils.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/ExtractorUtils.scala
@@ -1,6 +1,8 @@
 package fi.oph.ovara.backend.utils
 
 import fi.oph.ovara.backend.domain.*
+import org.json4s.{jvalue2extractable, JArray, JObject}
+import org.json4s.jackson.JsonMethods.parse
 import org.json4s.jackson.Serialization.read
 import slick.jdbc.PositionedResult
 
@@ -24,7 +26,14 @@ object ExtractorUtils extends GenericOvaraJsonFormats {
     json.map(read[Map[Kieli, String]]).getOrElse(Map())
 
   def extractKielistettyList(json: Option[String]): List[Kielistetty] = {
-    json.map(read[List[Kielistetty]]).getOrElse(List())
+    json
+      .map { jsonStr =>
+        parse(jsonStr) match {
+          case JArray(arr) => arr.collect { case obj: JObject => obj.extract[Kielistetty] }
+          case _           => List()
+        }
+      }
+      .getOrElse(List())
   }
 
   def extractArray(json: Option[String]): List[String] = {

--- a/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/GenericOvaraFormats.scala
+++ b/ovara-backend/src/main/scala/fi/oph/ovara/backend/utils/GenericOvaraFormats.scala
@@ -12,6 +12,7 @@ import org.json4s.{
   DefaultFormats,
   Extraction,
   Formats,
+  JNothing,
   JNull,
   JValue,
   MappingException
@@ -78,9 +79,18 @@ trait GenericOvaraFormats {
 
         Valintatapajono(
           valintatapajonoOid = (s \ "valintatapajono_oid").extract[String],
-          valintatapajononNimi = (s \ "valintatapajono_nimi").extract[String],
-          valinnanTila = (s \ "valinnan_tila").extract[String],
-          valinnanTilanKuvaus = (s \ "valinnantilan_kuvauksen_teksti").extract[Kielistetty]
+          valintatapajononNimi = (s \ "valintatapajono_nimi") match {
+            case JNull | JNothing => "Valintatapajono"
+            case v                => v.extract[String]
+          },
+          valinnanTila = (s \ "valinnan_tila") match {
+            case JNull | JNothing => ""
+            case v                => v.extract[String]
+          },
+          valinnanTilanKuvaus = (s \ "valinnantilan_kuvauksen_teksti") match {
+            case JNull | JNothing => Map.empty
+            case v                => v.extract[Kielistetty]
+          }
         )
       },
       { case v: Valintatapajono =>

--- a/ovara-backend/src/test/scala/fi/oph/ovara/backend/utils/ExtractorUtilsSpec.scala
+++ b/ovara-backend/src/test/scala/fi/oph/ovara/backend/utils/ExtractorUtilsSpec.scala
@@ -34,6 +34,20 @@ class ExtractorUtilsSpec extends AnyFlatSpec {
       )
     )
   }
+  "extractKielistettyList" should "return empty list when input is None" in {
+    assert(ExtractorUtils.extractKielistettyList(None) == List())
+  }
+
+  it should "skip null elements in the JSON array" in {
+    val json = Some("""[null, {"fi": "Suomi", "sv": "Finland"}]""")
+    assert(ExtractorUtils.extractKielistettyList(json) == List(Map(Fi -> "Suomi", Sv -> "Finland")))
+  }
+
+  it should "return all elements when none are null" in {
+    val json = Some("""[{"fi": "Suomi"}, {"fi": "Ruotsi"}]""")
+    assert(ExtractorUtils.extractKielistettyList(json).length == 2)
+  }
+
   "extractCommaSeparatedString" should "return None for an empty list and a comma-separated string for a non-empty list" in {
     assert(ExtractorUtils.extractCommaSeparatedString(None) == None)
     assert(ExtractorUtils.extractCommaSeparatedString(Some("[]")) == None)


### PR DESCRIPTION
## Ongelma

\"Korkeakoulujen hakijat\" -raportti tuotti virheen Oulun amk:lle haulla \"Korkeakoulujen yhteishaku syksy 2024\" (koulutus alkaa 2025 kevät). Loki näytti `UndeclaredThrowableException`, jonka juurisyy oli `org.json4s.MappingException: Expected object but got JNull`.

Poikkeus syntyi, kun json4s strict-moodissa yritti lukea `kansalaisuudet_nimi`-sarakkeen JSON-taulukkoa, jossa oli `null`-alkio.

## Muutokset

### `extractKielistettyList`
Aiempi `read[List[Kielistetty]]` kaatui `null`-alkioon JSON-taulukossa. Uusi toteutus parsii JSON:n ensin `JValue`:ksi ja käyttää `collect { case obj: JObject => ... }` -rakennetta, joka ohittaa `null`-alkiot automaattisesti.

### `valintatapajonoSerializer`
Lisätty `JNull | JNothing` -käsittely kentille `valintatapajono_nimi`, `valinnan_tila` ja `valinnantilan_kuvauksen_teksti`. Nämä kentät voivat olla `null` joidenkin hakujen datassa, mikä aiheutti saman kaatumisen.